### PR TITLE
[feat/#25]: 랜딩 페이지 UI 구성 및 애니메이션 설정

### DIFF
--- a/app/components/Header.tsx
+++ b/app/components/Header.tsx
@@ -18,7 +18,7 @@ export default function Header() {
 
         <nav className="flex space-x-10 ml-[75px]">
           <Link
-            href="/games"
+            href="/game"
             className="text-white text-[24px] leading-[32px] font-semibold hover:opacity-80"
           >
             게임
@@ -42,7 +42,7 @@ export default function Header() {
             </button>
 
             {/* 마이페이지 버튼 */}
-            <Link href="/mypage">
+            <Link href="/profile">
               <Button label="마이 페이지" size="medium" type="black" />
             </Link>
 

--- a/app/components/LandingCard.tsx
+++ b/app/components/LandingCard.tsx
@@ -1,0 +1,59 @@
+'use client';
+
+import Image from 'next/image';
+import { useRouter } from 'next/navigation';
+import Button from './Button';
+
+interface LandingCardProps {
+  href: string;
+  iconSrc: string;
+  iconAlt: string;
+  title: string;
+  description: string;
+  animationDelay?: string;
+  buttonLabel?: string;
+}
+
+export default function LandingCard({
+  href,
+  iconSrc,
+  iconAlt,
+  title,
+  description,
+  animationDelay = '0s',
+  buttonLabel = '시작하기',
+}: LandingCardProps) {
+  const router = useRouter();
+
+  const handleClick = () => {
+    router.push(href);
+  };
+
+  return (
+    <div
+        className="bg-background-300 hover:bg-primary-purple-100/10 p-8 rounded-xl text-center 
+             transition-all duration-300 ease-out transform 
+             hover:scale-[1.05] hover:-translate-y-1 hover:shadow-xl 
+             cursor-pointer shadow-md h-[360px] flex flex-col animate-fade-in-up"
+        style={{ animationDelay }}
+    >
+      {/* 아이콘 */}
+      <div className="flex justify-center mb-6">
+        <Image src={iconSrc} alt={iconAlt} width={64} height={64} />
+      </div>
+
+      {/* 텍스트 그룹 */}
+      <div className="flex flex-col items-center flex-1 justify-start">
+        <h2 className="text-h2 font-semibold mb-2">{title}</h2>
+        <p className="text-body text-font-200 max-w-[240px] leading-relaxed text-center mb-4">
+          {description}
+        </p>
+      </div>
+
+      {/* 버튼 */}
+      <div className="mt-auto pt-4">
+        <Button label={buttonLabel} size="medium" type="purple" onClick={handleClick} />
+      </div>
+    </div>
+  );
+}

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,12 +1,39 @@
+import LandingCard from './components/LandingCard';
+
 export default function Home() {
   return (
-    <>
-      {/* 메인 콘텐츠 */}
-      <div className="grid grid-rows-[20px_1fr_20px] items-center justify-items-center min-h-screen p-8 pb-20 gap-16 sm:p-20 font-sans">
-        <main className="flex flex-col gap-[32px] row-start-2 items-center sm:items-start">
-          {/* 메인 콘텐츠 */}
-        </main>
+    <div className="min-h-[calc(100vh-80px)] px-8 pb-20 sm:px-20 font-sans bg-background-400 text-font-100 flex items-center justify-center">
+      <div className="flex flex-col items-center gap-[48px] w-full max-w-[1024px]">
+        {/* 텍스트 블럭 */}
+        <div className="text-center w-full animate-fade-in-left">
+          <h1 className="text-headline font-bold mb-4">
+            게임 <span className="text-primary-purple-200">추천</span>과 <span className="text-primary-purple-200">토론</span>의 장
+          </h1>
+          <p className="text-body text-font-200">
+            원하는 서비스를 선택하여 게임에 대한 열정을 함께 나눠보세요!
+          </p>
+        </div>
+
+        {/* 카드 메뉴 */}
+        <div className="grid grid-cols-1 sm:grid-cols-2 gap-8 w-full">
+          <LandingCard
+            href="/game"
+            iconSrc="/icons/gamesearch.svg"
+            iconAlt="게임 탐색"
+            title="게임 탐색"
+            description="다양한 장르와 플랫폼의 게임을 탐색하고 자세한 정보를 확인해보세요. 당신에게 맞는 게임을 찾아드립니다."
+            animationDelay="0.2s"
+          />
+          <LandingCard
+            href="/arena"
+            iconSrc="/icons/arena.svg"
+            iconAlt="투기장"
+            title="투기장"
+            description="게임에 대한 열띤 토론에 참여하세요. 자신의 의견을 피력하고 다른 게이머들과 논쟁을 벌여보세요."
+            animationDelay="0.4s"
+          />
+        </div>
       </div>
-    </>
+    </div>
   );
 }

--- a/public/icons/arena.svg
+++ b/public/icons/arena.svg
@@ -1,0 +1,15 @@
+<svg width="82" height="82" viewBox="0 0 82 82" fill="none" xmlns="http://www.w3.org/2000/svg">
+<mask id="path-1-inside-1_276_19" fill="white">
+<path d="M0 41C0 18.3563 18.3563 0 41 0C63.6437 0 82 18.3563 82 41C82 63.6437 63.6437 82 41 82C18.3563 82 0 63.6437 0 41Z"/>
+</mask>
+<path d="M0 41C0 18.3563 18.3563 0 41 0C63.6437 0 82 18.3563 82 41C82 63.6437 63.6437 82 41 82C18.3563 82 0 63.6437 0 41Z" fill="#581C87" fill-opacity="0.5"/>
+<path d="M41 82V81C18.9086 81 1 63.0914 1 41H0H-1C-1 64.196 17.804 83 41 83V82ZM82 41H81C81 63.0914 63.0914 81 41 81V82V83C64.196 83 83 64.196 83 41H82ZM41 0V1C63.0914 1 81 18.9086 81 41H82H83C83 17.804 64.196 -1 41 -1V0ZM41 0V-1C17.804 -1 -1 17.804 -1 41H0H1C1 18.9086 18.9086 1 41 1V0Z" fill="#7E22CE" fill-opacity="0.5" mask="url(#path-1-inside-1_276_19)"/>
+<path d="M46 52L23 29V23H29L52 46" stroke="#C084FC" stroke-width="4" stroke-linecap="round" stroke-linejoin="round"/>
+<path d="M43 55L55 43" stroke="#C084FC" stroke-width="4" stroke-linecap="round" stroke-linejoin="round"/>
+<path d="M49 49L57 57" stroke="#C084FC" stroke-width="4" stroke-linecap="round" stroke-linejoin="round"/>
+<path d="M55 59L59 55" stroke="#C084FC" stroke-width="4" stroke-linecap="round" stroke-linejoin="round"/>
+<path d="M46 30L53 23H59V29L52 36" stroke="#C084FC" stroke-width="4" stroke-linecap="round" stroke-linejoin="round"/>
+<path d="M27 45L35 53" stroke="#C084FC" stroke-width="4" stroke-linecap="round" stroke-linejoin="round"/>
+<path d="M31 51L25 57" stroke="#C084FC" stroke-width="4" stroke-linecap="round" stroke-linejoin="round"/>
+<path d="M23 55L27 59" stroke="#C084FC" stroke-width="4" stroke-linecap="round" stroke-linejoin="round"/>
+</svg>

--- a/public/icons/gamesearch.svg
+++ b/public/icons/gamesearch.svg
@@ -1,0 +1,9 @@
+<svg width="82" height="82" viewBox="0 0 82 82" fill="none" xmlns="http://www.w3.org/2000/svg">
+<mask id="path-1-inside-1_276_1561" fill="white">
+<path d="M0 41C0 18.3563 18.3563 0 41 0C63.6437 0 82 18.3563 82 41C82 63.6437 63.6437 82 41 82C18.3563 82 0 63.6437 0 41Z"/>
+</mask>
+<path d="M0 41C0 18.3563 18.3563 0 41 0C63.6437 0 82 18.3563 82 41C82 63.6437 63.6437 82 41 82C18.3563 82 0 63.6437 0 41Z" fill="#581C87" fill-opacity="0.5"/>
+<path d="M41 82V81C18.9086 81 1 63.0914 1 41H0H-1C-1 64.196 17.804 83 41 83V82ZM82 41H81C81 63.0914 63.0914 81 41 81V82V83C64.196 83 83 64.196 83 41H82ZM41 0V1C63.0914 1 81 18.9086 81 41H82H83C83 17.804 64.196 -1 41 -1V0ZM41 0V-1C17.804 -1 -1 17.804 -1 41H0H1C1 18.9086 18.9086 1 41 1V0Z" fill="#7E22CE" fill-opacity="0.5" mask="url(#path-1-inside-1_276_1561)"/>
+<path d="M41 61C52.0457 61 61 52.0457 61 41C61 29.9543 52.0457 21 41 21C29.9543 21 21 29.9543 21 41C21 52.0457 29.9543 61 41 61Z" stroke="#C084FC" stroke-width="4" stroke-linecap="round" stroke-linejoin="round"/>
+<path d="M49.48 32.52L45.24 45.24L32.52 49.48L36.76 36.76L49.48 32.52Z" stroke="#C084FC" stroke-width="4" stroke-linecap="round" stroke-linejoin="round"/>
+</svg>

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -3,6 +3,20 @@ import type { Config } from "tailwindcss";
 const config: Config = {
     theme: {
         extend: {
+           animation: {
+            'fade-in-left': 'fadeInLeft 0.8s ease-out forwards',
+            'fade-in-up': 'fadeInUp 0.8s ease-out forwards',
+            },
+            keyframes: {
+                fadeInLeft: {
+                    '0%': { opacity: '0', transform: 'translateX(-20px)' },
+                    '100%': { opacity: '1', transform: 'translateX(0)' },
+                },
+                fadeInUp: {
+                    '0%': { opacity: '0', transform: 'translateY(20px)' },
+                    '100%': { opacity: '1', transform: 'translateY(0)' },
+                },
+            },
             fontSize: {
                 headline: ["32px", "40px"], // 큰제목
                 h2: ["24px", "32px"], // 소제목


### PR DESCRIPTION
## ✨ 작업 개요

* 랜딩 페이지 UI 구성 및 애니메이션 설정

## ✅ 상세 내용

-   [ ] 랜딩 카드 컴포넌트 추가 및 메인페이지 초기 구성
-   [ ] 페이지 접속 시 텍스트와 카드간의 애니메이션 추가
-   [ ] 각 카드 호버링시 호버링 효과 추가

## 📸 스크린샷 (선택)

![메인 페이지](https://github.com/user-attachments/assets/2b8500c7-649d-4422-9939-a1c9d011fa5f)


## 🧪 확인 사항

-   [ ] 정상적으로 동작하는지 직접 테스트해봤나요?
-   [ ] 기능 추가/수정 후 UI나 비즈니스 로직에 영향은 없나요?
-   [ ] PR 리뷰어가 중점적으로 확인하면 좋을 부분은?

## 🙏 기타 참고 사항

## 이슈 관리

close #25
