### PR TITLE
[feat/#28]: 로그인 페이지 레이아웃 구현

### DIFF
--- a/app/(auth)/log-in/page.tsx
+++ b/app/(auth)/log-in/page.tsx
@@ -1,0 +1,82 @@
+'use client';
+
+import Image from 'next/image';
+import Link from 'next/link';
+import { useState } from 'react';
+import Input from '@/app/components/Input/Input';
+import Button from '@/app/components/Button';
+
+export default function LoginPage() {
+  const [email, setEmail] = useState('');
+  const [password, setPassword] = useState('');
+  const [emailError, setEmailError] = useState('');
+
+  const handleSubmit = (e: React.FormEvent) => {
+    e.preventDefault();
+    // 간단한 유효성 검사
+    const emailRegex = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
+    if (!emailRegex.test(email)) {
+      setEmailError('이메일 형식이 잘못되었습니다.');
+      return;
+    }
+    setEmailError('');
+    // 로그인 로직
+    console.log('로그인 요청:', { email, password });
+  };
+
+  return (
+    <div className="min-h-screen flex items-center justify-center bg-background-400 font-sans">
+      <div className="bg-background-300 p-10 rounded-xl w-full max-w-[400px] shadow-lg">
+        <div className="flex justify-center mb-8">
+          <Image
+            src="/icons/logo.svg" // 너가 등록한 전체 로고
+            alt="GAMECHU 로고"
+            width={160}
+            height={160}
+          />
+        </div>
+
+        <form onSubmit={handleSubmit} className="flex flex-col gap-6">
+          {/* 이메일 */}
+          <div>
+            <label className="block text-font-100 font-semibold mb-2 text-body">이메일</label>
+            <Input
+              type="email"
+              placeholder="이메일 주소를 입력하세요"
+              value={email}
+              onChange={(e) => setEmail(e.target.value)}
+              hasError={!!emailError}
+            />
+            {emailError && (
+              <p className="text-caption text-state-error mt-1">{emailError}</p>
+            )}
+          </div>
+
+          {/* 비밀번호 */}
+          <div>
+            <label className="block text-font-100 font-semibold mb-2 text-body">비밀번호</label>
+            <Input
+              type="password"
+              placeholder="비밀번호를 입력하세요"
+              value={password}
+              onChange={(e) => setPassword(e.target.value)}
+            />
+          </div>
+
+          {/* 로그인 버튼 */}
+          <div className="flex justify-center">
+            <Button label="로그인" size="large" type="purple" htmlType="submit" />
+          </div>
+
+          {/* 회원가입 링크 */}
+          <p className="text-center text-caption text-font-200 mt-2">
+            회원이 아니신가요?{' '}
+            <Link href="sign-up" className="text-primary-purple-100 font-semibold hover:underline">
+              회원가입
+            </Link>
+          </p>
+        </form>
+      </div>
+    </div>
+  );
+}

--- a/app/(base)/layout.tsx
+++ b/app/(base)/layout.tsx
@@ -1,0 +1,18 @@
+import Footer from "../components/Footer";
+import Header from "../components/Header";
+import "../globals.css";
+export { viewport } from "../viewport";
+
+export default function RootLayout({
+    children,
+}: {
+    children: React.ReactNode;
+}) {
+    return (
+        <>
+                <Header />
+                <main>{children}</main>
+                <Footer />
+        </>   
+    );
+}

--- a/app/(base)/page.tsx
+++ b/app/(base)/page.tsx
@@ -1,4 +1,4 @@
-import LandingCard from './components/LandingCard';
+import LandingCard from '../components/LandingCard';
 
 export default function Home() {
   return (

--- a/app/components/Header.tsx
+++ b/app/components/Header.tsx
@@ -1,12 +1,14 @@
-"use client";
+'use client';
 
 import Image from "next/image";
 import Link from "next/link";
+import { useRouter } from "next/navigation";
 import { useState } from "react";
 import Button from "./Button";
 
 export default function Header() {
-  const [isLoggedIn, setIsLoggedIn] = useState(false); // 테스트용 상태
+  const [isLoggedIn, setIsLoggedIn] = useState(false); // 테스트용
+  const router = useRouter();
 
   return (
     <header className="w-full h-[100px] bg-[#191919] flex items-center justify-between font-sans">
@@ -36,17 +38,14 @@ export default function Header() {
       <div className="flex items-center space-x-4 mr-[75px]">
         {isLoggedIn ? (
           <>
-            {/* 알림 아이콘 */}
             <button className="text-primary-purple-100 hover:opacity-80">
               <Image src="/icons/bell.svg" alt="알림" width={24} height={24} />
             </button>
 
-            {/* 마이페이지 버튼 */}
             <Link href="/profile">
               <Button label="마이 페이지" size="medium" type="black" />
             </Link>
 
-            {/* 로그아웃 버튼 */}
             <Button
               label="로그아웃"
               size="medium"
@@ -59,7 +58,7 @@ export default function Header() {
             label="로그인"
             size="medium"
             type="purple"
-            onClick={() => setIsLoggedIn(true)}
+            onClick={() => router.push("/log-in")}
           />
         )}
       </div>

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,20 +1,14 @@
-import Footer from "./components/Footer";
-import Header from "./components/Header";
-import "./globals.css";
-export { viewport } from "./viewport";
-
+// app/layout.tsx
 export default function RootLayout({
-    children,
+  children,
 }: {
-    children: React.ReactNode;
+  children: React.ReactNode;
 }) {
-    return (
-        <html lang="ko">
-            <body className="font-sans bg-background-400 text-font-100">
-                <Header />
-                <main className="max-w-[1400px] mx-auto px-10">{children}</main>
-                <Footer />
-            </body>
-        </html>
-    );
+  return (
+    <html lang="ko">
+      <body className="font-sans bg-background-400 text-font-100">
+        {children}
+      </body>
+    </html>
+  );
 }


### PR DESCRIPTION
## ✨ 작업 개요

* 로그인 페이지 레이아웃 구현

## ✅ 상세 내용

-   [ ] 로그인 페이지 레아아웃 구현
-   [ ] 헤더, 푸터 관련 레이아웃 설정 변경

## 📸 스크린샷 (선택)

![로그인](https://github.com/user-attachments/assets/72a610bb-6467-4bcc-bbb1-a4abd2534142)


## 🧪 확인 사항

-   [ ] 정상적으로 동작하는지 직접 테스트해봤나요?
-   [ ] 기능 추가/수정 후 UI나 비즈니스 로직에 영향은 없나요?
-   [ ] PR 리뷰어가 중점적으로 확인하면 좋을 부분은?

## 🙏 기타 참고 사항

## 이슈 관리

close #28
