### PR TITLE
[feat/#47]: 이메일 중복체크 및 회원가입 기능 추가

### DIFF
--- a/app/(auth)/components/StepProfile.tsx
+++ b/app/(auth)/components/StepProfile.tsx
@@ -11,18 +11,15 @@ interface Props {
 export default function StepProfile({ onNext }: Props) {
     const [nickname, setNickname] = useState("");
     const [email, setEmail] = useState("");
-    const [isEmailDuplicate, setIsEmailDuplicate] = useState<boolean | null>(
-        null
-    );
+    const [isEmailDuplicate, setIsEmailDuplicate] = useState<boolean | null>(null);
     const [password, setPassword] = useState("");
     const [confirm, setConfirm] = useState("");
     const [gender, setGender] = useState<"M" | "F" | null>(null);
     const [birth, setBirth] = useState("");
-    const [errorMessage, setErrorMessage] = useState("");
+    const [fieldErrors, setFieldErrors] = useState<Record<string, string>>({});
     const [successMessage, setSuccessMessage] = useState("");
 
-    const validateEmailFormat = (email: string) =>
-        /^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(email);
+    const validateEmailFormat = (email: string) => /^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(email);
 
     const isValidDate = (dateString: string): boolean => {
         const year = parseInt(dateString.substring(0, 4), 10);
@@ -38,70 +35,59 @@ export default function StepProfile({ onNext }: Props) {
 
     const checkEmailDuplicate = async () => {
         setSuccessMessage("");
-        setErrorMessage("");
+        setFieldErrors((prev) => ({ ...prev, email: "" }));
 
         if (!validateEmailFormat(email)) {
-            setErrorMessage("올바른 이메일 형식이 아닙니다.");
+            setFieldErrors((prev) => ({ ...prev, email: "올바른 이메일 형식이 아닙니다." }));
             setIsEmailDuplicate(null);
             return;
         }
 
         try {
-            const res = await fetch(
-                `/api/auth/email-check?email=${encodeURIComponent(email)}`
-            );
-            let data;
-            try {
-                data = await res.json();
-            } catch {
-                throw new Error("서버 응답을 처리할 수 없습니다.");
+            const res = await fetch(`/api/auth/email-check?email=${encodeURIComponent(email)}`);
+            const data = await res.json();
+
+            if (res.status === 409) {
+                setFieldErrors((prev) => ({ ...prev, email: data.message }));
+                setIsEmailDuplicate(true);
+                return;
             }
 
             if (!res.ok) {
-                throw new Error(data.error || "중복 확인 실패");
+                throw new Error(data.message || "중복 확인 실패");
             }
 
-            setIsEmailDuplicate(data.isDuplicate);
-            setSuccessMessage(
-                data.isDuplicate
-                    ? "이미 사용 중인 이메일입니다."
-                    : "사용 가능한 이메일입니다."
-            );
+            setIsEmailDuplicate(false);
+            setSuccessMessage(data.message);
         } catch (err) {
-            const message =
-                err instanceof Error ? err.message : "오류가 발생했습니다.";
-            setErrorMessage(message);
+            const message = err instanceof Error ? err.message : "오류가 발생했습니다.";
+            setFieldErrors((prev) => ({ ...prev, email: message }));
             setIsEmailDuplicate(null);
         }
     };
 
     const handleNext = async () => {
         setSuccessMessage("");
-        setErrorMessage("");
+        const errors: Record<string, string> = {};
 
-        if (!nickname || !email || !password || !confirm || !gender || !birth) {
-            setErrorMessage("모든 항목을 입력해주세요.");
-            return;
-        }
-        if (!validateEmailFormat(email)) {
-            setErrorMessage("올바른 이메일 형식이 아닙니다.");
-            return;
-        }
-        if (isEmailDuplicate === null) {
-            setErrorMessage("이메일 중복 검사를 진행해주세요.");
-            return;
-        }
-        if (isEmailDuplicate === true) {
-            setErrorMessage("이미 사용 중인 이메일입니다.");
-            return;
-        }
-        if (password !== confirm) {
-            setErrorMessage("비밀번호가 일치하지 않습니다.");
-            return;
-        }
+        if (!nickname) errors.nickname = "닉네임을 입력해주세요.";
+        if (!email) errors.email = "이메일을 입력해주세요.";
+        else if (!validateEmailFormat(email)) errors.email = "올바른 이메일 형식이 아닙니다.";
+        else if (isEmailDuplicate === null) errors.email = "이메일 중복 검사를 진행해주세요.";
+        else if (isEmailDuplicate) errors.email = "이미 사용 중인 이메일입니다.";
+
+        if (!password) errors.password = "비밀번호를 입력해주세요.";
+        if (!confirm) errors.confirm = "비밀번호 확인을 입력해주세요.";
+        if (password && confirm && password !== confirm) errors.confirm = "비밀번호가 일치하지 않습니다.";
+
+        if (!gender) errors.gender = "성별을 선택해주세요.";
+
         const birthRegex = /^\d{8}$/;
-        if (!birthRegex.test(birth) || !isValidDate(birth)) {
-            setErrorMessage("유효한 생년월일을 입력해주세요.");
+        if (!birth) errors.birth = "생년월일을 입력해주세요.";
+        else if (!birthRegex.test(birth) || !isValidDate(birth)) errors.birth = "유효한 생년월일을 입력해주세요.";
+
+        if (Object.keys(errors).length > 0) {
+            setFieldErrors(errors);
             return;
         }
 
@@ -109,45 +95,33 @@ export default function StepProfile({ onNext }: Props) {
             const res = await fetch("/api/auth/signup", {
                 method: "POST",
                 headers: { "Content-Type": "application/json" },
-                body: JSON.stringify({
-                    nickname,
-                    email,
-                    password,
-                    birthDate: birth,
-                    gender,
-                }),
+                body: JSON.stringify({ nickname, email, password, birthDate: birth, gender }),
             });
 
             const data = await res.json();
-            if (!res.ok) throw new Error(data.error || "회원가입 실패");
+            if (!res.ok) throw new Error(data.message || "회원가입 실패");
 
             sessionStorage.setItem("memberId", data.memberId);
             setSuccessMessage("회원가입 성공!");
             onNext();
         } catch (err) {
-            const message =
-                err instanceof Error ? err.message : "회원가입 중 오류 발생";
-            setErrorMessage(message);
+            const message = err instanceof Error ? err.message : "회원가입 중 오류 발생";
+            setFieldErrors({ general: message });
         }
     };
 
     return (
         <div className="space-y-6">
-            <div>
-                <label className="block mb-1 text-body text-font-100 font-semibold">
-                    닉네임
-                </label>
-                <Input
-                    placeholder="닉네임을 입력하세요"
-                    value={nickname}
-                    onChange={(e) => setNickname(e.target.value)}
-                />
+            <div className="space-y-1">
+                <label className="block text-body text-font-100 font-semibold">닉네임</label>
+                <Input placeholder="닉네임을 입력하세요" value={nickname} onChange={(e) => setNickname(e.target.value)} />
+                <div className="min-h-8px]">
+                    {fieldErrors.nickname && <p className="text-caption text-state-error mt-1">{fieldErrors.nickname}</p>}
+                </div>
             </div>
 
-            <div>
-                <label className="block mb-1 text-body text-font-100 font-semibold">
-                    이메일
-                </label>
+            <div className="space-y-1">
+                <label className="block text-body text-font-100 font-semibold">이메일</label>
                 <div className="flex gap-2 items-start">
                     <div className="flex-1">
                         <Input
@@ -159,56 +133,33 @@ export default function StepProfile({ onNext }: Props) {
                             }}
                         />
                     </div>
-                    <Button
-                        label="중복 검사"
-                        size="small"
-                        type="black"
-                        onClick={checkEmailDuplicate}
-                    />
+                    <Button label="중복 검사" size="small" type="black" onClick={checkEmailDuplicate} />
+                </div>
+                <div className="min-h-8px]">
+                    {fieldErrors.email && <p className="text-caption text-state-error mt-1">{fieldErrors.email}</p>}
+                    {!fieldErrors.email && successMessage && <p className="text-caption text-state-success mt-1">{successMessage}</p>}
                 </div>
             </div>
-            <div>
-                {errorMessage && (
-                    <p className="text-caption text-state-error mb-4">
-                        {errorMessage}
-                    </p>
-                )}
-                {successMessage && (
-                    <p className="text-caption text-state-success mb-4">
-                        {successMessage}
-                    </p>
-                )}
+
+            <div className="space-y-1">
+                <label className="block text-body text-font-100 font-semibold">비밀번호</label>
+                <Input type="password" placeholder="비밀번호를 입력하세요" value={password} onChange={(e) => setPassword(e.target.value)} />
+                <div className="min-h-[8px]">
+                    {fieldErrors.password && <p className="text-caption text-state-error mt-1">{fieldErrors.password}</p>}
+                </div>
             </div>
 
-            <div>
-                <label className="block mb-1 text-body text-font-100 font-semibold">
-                    비밀번호
-                </label>
-                <Input
-                    type="password"
-                    placeholder="비밀번호를 입력하세요"
-                    value={password}
-                    onChange={(e) => setPassword(e.target.value)}
-                />
+            <div className="space-y-1">
+                <label className="block text-body text-font-100 font-semibold">비밀번호 확인</label>
+                <Input type="password" placeholder="비밀번호를 다시 입력하세요" value={confirm} onChange={(e) => setConfirm(e.target.value)} />
+                <div className="min-h-8px]">
+                    {fieldErrors.confirm && <p className="text-caption text-state-error mt-1">{fieldErrors.confirm}</p>}
+                </div>
             </div>
 
-            <div>
-                <label className="block mb-1 text-body text-font-100 font-semibold">
-                    비밀번호 확인
-                </label>
-                <Input
-                    type="password"
-                    placeholder="비밀번호를 다시 입력하세요"
-                    value={confirm}
-                    onChange={(e) => setConfirm(e.target.value)}
-                />
-            </div>
-
-            <div>
-                <label className="block mb-1 text-body text-font-100 font-semibold">
-                    성별
-                </label>
-                <div className="flex justify-center gap-4 mb-6">
+            <div className="space-y-1">
+                <label className="block text-body text-font-100 font-semibold">성별</label>
+                <div className="flex justify-center gap-4">
                     <button
                         onClick={() => setGender("M")}
                         className={`w-[150px] h-[50px] rounded-xl font-semibold transition-all duration-200 ${
@@ -230,18 +181,22 @@ export default function StepProfile({ onNext }: Props) {
                         여자
                     </button>
                 </div>
+                <div className="min-h-8px]">
+                    {fieldErrors.gender && <p className="text-caption text-state-error text-center mt-1">{fieldErrors.gender}</p>}
+                </div>
             </div>
 
-            <div>
-                <label className="block mb-1 text-body text-font-100 font-semibold">
-                    생년월일
-                </label>
-                <Input
-                    placeholder="ex) 20000101"
-                    value={birth}
-                    onChange={(e) => setBirth(e.target.value)}
-                />
+            <div className="space-y-1">
+                <label className="block text-body text-font-100 font-semibold">생년월일</label>
+                <Input placeholder="ex) 20000101" value={birth} onChange={(e) => setBirth(e.target.value)} />
+                <div className="min-h-[8px]">
+                    {fieldErrors.birth && <p className="text-caption text-state-error mt-1">{fieldErrors.birth}</p>}
+                </div>
             </div>
+
+            {fieldErrors.general && (
+                <p className="text-caption text-state-error mt-2">{fieldErrors.general}</p>
+            )}
 
             <div className="mt-8 text-right">
                 <Button label="다음 →" onClick={handleNext} />

--- a/app/api/auth/email-check/route.ts
+++ b/app/api/auth/email-check/route.ts
@@ -1,0 +1,29 @@
+import { NextRequest, NextResponse } from "next/server";
+import { PrismaMemberRepository } from "@/backend/member/infra/repositories/prisma/PrismaMemberRepository";
+import { EmailCheckUsecase } from "@/backend/member/application/usecase/EmailCheckUsecase";
+import { EmailCheckResponseDto } from "@/backend/member/application/usecase/dto/EmailCheckResponseDto";
+
+export async function GET(
+    req: NextRequest
+): Promise<NextResponse<EmailCheckResponseDto | { error: string }>> {
+    const { searchParams } = new URL(req.url);
+    const email = searchParams.get("email");
+
+    if (!email) {
+        return NextResponse.json(
+            { error: "이메일이 누락되었습니다." },
+            { status: 400 }
+        );
+    }
+
+    const repo = new PrismaMemberRepository();
+    const usecase = new EmailCheckUsecase(repo);
+
+    try {
+        const result: EmailCheckResponseDto = await usecase.execute(email);
+        return NextResponse.json(result, { status: 200 });
+    } catch (err) {
+        const message = err instanceof Error ? err.message : "서버 오류 발생";
+        return NextResponse.json({ error: message }, { status: 500 });
+    }
+}

--- a/app/api/auth/email-check/route.ts
+++ b/app/api/auth/email-check/route.ts
@@ -1,29 +1,38 @@
+// /app/api/auth/email-check/route.ts
 import { NextRequest, NextResponse } from "next/server";
 import { PrismaMemberRepository } from "@/backend/member/infra/repositories/prisma/PrismaMemberRepository";
 import { EmailCheckUsecase } from "@/backend/member/application/usecase/EmailCheckUsecase";
-import { EmailCheckResponseDto } from "@/backend/member/application/usecase/dto/EmailCheckResponseDto";
 
-export async function GET(
-    req: NextRequest
-): Promise<NextResponse<EmailCheckResponseDto | { error: string }>> {
-    const { searchParams } = new URL(req.url);
-    const email = searchParams.get("email");
+export async function GET(req: NextRequest) {
+  const { searchParams } = new URL(req.url);
+  const email = searchParams.get("email");
 
-    if (!email) {
-        return NextResponse.json(
-            { error: "이메일이 누락되었습니다." },
-            { status: 400 }
-        );
+  if (!email) {
+    return NextResponse.json(
+      { message: "이메일이 누락되었습니다." },
+      { status: 400 }
+    );
+  }
+
+  const repo = new PrismaMemberRepository();
+  const usecase = new EmailCheckUsecase(repo);
+
+  try {
+    const result = await usecase.execute(email);
+
+    if (result.isDuplicate) {
+      return NextResponse.json(
+        { message: "이미 존재하는 이메일입니다." },
+        { status: 409 }
+      );
     }
 
-    const repo = new PrismaMemberRepository();
-    const usecase = new EmailCheckUsecase(repo);
-
-    try {
-        const result: EmailCheckResponseDto = await usecase.execute(email);
-        return NextResponse.json(result, { status: 200 });
-    } catch (err) {
-        const message = err instanceof Error ? err.message : "서버 오류 발생";
-        return NextResponse.json({ error: message }, { status: 500 });
-    }
+    return NextResponse.json(
+      { message: "사용 가능한 이메일입니다." },
+      { status: 200 }
+    );
+  } catch (err) {
+    const message = err instanceof Error ? err.message : "서버 오류 발생";
+    return NextResponse.json({ message }, { status: 500 });
+  }
 }

--- a/app/api/auth/signup/route.ts
+++ b/app/api/auth/signup/route.ts
@@ -1,0 +1,32 @@
+import { NextRequest, NextResponse } from "next/server";
+import { PrismaMemberRepository } from "@/backend/member/infra/repositories/prisma/PrismaMemberRepository";
+import { SignUpUsecase } from "@/backend/member/application/usecase/SignUpUsecase";
+import { SignUpRequestDto } from "@/backend/member/application/usecase/dto/SignUpRequestDto";
+
+export async function POST(req: NextRequest) {
+    try {
+        const { nickname, email, password, birthDate, gender } =
+            await req.json();
+
+        const dto = new SignUpRequestDto(
+            nickname,
+            email,
+            password,
+            birthDate,
+            gender
+        );
+        const repo = new PrismaMemberRepository();
+        const usecase = new SignUpUsecase(repo);
+
+        const user = await usecase.execute(dto);
+
+        return NextResponse.json(
+            { message: "회원가입 성공", memberId: user.id, email: user.email },
+            { status: 201 }
+        );
+    } catch (err) {
+        const message =
+            err instanceof Error ? err.message : "서버 오류가 발생했습니다.";
+        return NextResponse.json({ error: message }, { status: 400 });
+    }
+}

--- a/backend/member/application/usecase/EmailCheckUsecase.ts
+++ b/backend/member/application/usecase/EmailCheckUsecase.ts
@@ -1,0 +1,12 @@
+// /backend/member/application/usecase/CheckEmailUsecase.ts
+import { MemberRepository } from "@/backend/member/domain/repositories/MemberRepository";
+import { EmailCheckResponseDto } from "./dto/EmailCheckResponseDto";
+
+export class EmailCheckUsecase {
+    constructor(private repo: MemberRepository) {}
+
+    async execute(email: string): Promise<EmailCheckResponseDto> {
+        const member = await this.repo.findByEmail(email);
+        return new EmailCheckResponseDto(!!member);
+    }
+}

--- a/backend/member/application/usecase/SignUpUsecase.ts
+++ b/backend/member/application/usecase/SignUpUsecase.ts
@@ -1,0 +1,16 @@
+import { MemberRepository } from "@/backend/member/domain/repositories/MemberRepository";
+import { SignUpRequestDto } from "./dto/SignUpRequestDto";
+import { Member } from "@/prisma/generated";
+
+export class SignUpUsecase {
+    constructor(private repo: MemberRepository) {}
+
+    async execute(dto: SignUpRequestDto): Promise<Member> {
+        const existing = await this.repo.findByEmail(dto.email);
+        if (existing) {
+            throw new Error("이미 존재하는 이메일입니다.");
+        }
+
+        return await this.repo.create(dto);
+    }
+}

--- a/backend/member/application/usecase/dto/EmailCheckResponseDto.ts
+++ b/backend/member/application/usecase/dto/EmailCheckResponseDto.ts
@@ -1,0 +1,4 @@
+// /backend/member/application/usecase/dto/CheckEmailResponseDto.ts
+export class EmailCheckResponseDto {
+    constructor(public readonly isDuplicate: boolean) {}
+}

--- a/backend/member/application/usecase/dto/SignUpRequestDto.ts
+++ b/backend/member/application/usecase/dto/SignUpRequestDto.ts
@@ -1,0 +1,9 @@
+export class SignUpRequestDto {
+    constructor(
+        public readonly nickname: string,
+        public readonly email: string,
+        public readonly password: string,
+        public readonly birthDate: string, // YYYYMMDD
+        public readonly gender: "M" | "F"
+    ) {}
+}

--- a/backend/member/domain/repositories/MemberRepository.ts
+++ b/backend/member/domain/repositories/MemberRepository.ts
@@ -1,5 +1,7 @@
 import { Member } from "@/prisma/generated";
+import { SignUpRequestDto } from "../../application/usecase/dto/SignUpRequestDto";
 
 export interface MemberRepository {
-    findByEmail(email: string): Promise<Member | null>;
+    findByEmail(email: string): Promise<Member | null>;//로그인
+    create(data: SignUpRequestDto): Promise<Member>;//회원가입
 }

--- a/backend/member/infra/repositories/prisma/PrismaMemberRepository.ts
+++ b/backend/member/infra/repositories/prisma/PrismaMemberRepository.ts
@@ -1,11 +1,7 @@
-import {
-    PrismaClient,
-    Member,
-    
-} from "@/prisma/generated";
-
+import { PrismaClient, Member } from "@/prisma/generated";
 import { MemberRepository } from "@/backend/member/domain/repositories/MemberRepository";
-
+import { SignUpRequestDto } from "@/backend/member/application/usecase/dto/SignUpRequestDto";
+import bcrypt from "bcryptjs";
 
 export class PrismaMemberRepository implements MemberRepository {
     private prisma: PrismaClient;
@@ -18,5 +14,25 @@ export class PrismaMemberRepository implements MemberRepository {
         return this.prisma.member.findUnique({
             where: { email },
         });
+    }
+
+    async create(data: SignUpRequestDto): Promise<Member> {
+        const hashedPassword = await bcrypt.hash(data.password, 10);
+        
+        const member = await this.prisma.member.create({
+            data: {
+                nickname: data.nickname,
+                email: data.email,
+                password: hashedPassword,
+                birthDate: new Date(
+                    `${data.birthDate.slice(0, 4)}-${data.birthDate.slice(4, 6)}-${data.birthDate.slice(6, 8)}`
+                ),
+                isMale: data.gender === "M",
+                imageUrl: "@/public/images/default.png",
+                score: 500,
+            },
+        });
+
+        return member;
     }
 }


### PR DESCRIPTION
## ✨ 작업 개요

* 이메일 중복 체크 API 및 회원가입 로직 추가

## ✅ 상세 내용

-   [ ] 이메일 중복 체크 API 구현
-   [ ] 회원가입 API 및 기능 구현

## 📸 스크린샷 (선택)

회원가입 후 생성된 id 세션 스토리지에 임시 저장(추후 설문조사 완료 후 삭제 기능 추가 예정)

![세션 스토리지](https://github.com/user-attachments/assets/538f1c29-feab-45a6-a0e8-b4d96085282c)


## 🧪 확인 사항

-   [ ] 정상적으로 동작하는지 직접 테스트해봤나요?
-   [ ] 기능 추가/수정 후 UI나 비즈니스 로직에 영향은 없나요?
-   [ ] PR 리뷰어가 중점적으로 확인하면 좋을 부분은?

## 🙏 기타 참고 사항

* 회원가입 후 설문 조사 부분 구현 예정

## 이슈 관리

close #47 
