### PR TITLE
[fix/#99] 투기장 도전 예외처리

### DIFF
--- a/app/(base)/arena/[id]/components/ArenaDetailRecruiting.tsx
+++ b/app/(base)/arena/[id]/components/ArenaDetailRecruiting.tsx
@@ -15,6 +15,13 @@ export default function ArenaDetailRecruiting() {
         try {
             const memberId = await getAuthUserId(); // 🔐 로그인된 유저 ID 가져오기
             if (!memberId) throw new Error("로그인이 필요합니다.");
+            if (memberId === arenaDetail?.creatorId) {
+                throw new Error("본인이 만든 투기장에는 참가할 수 없습니다.");
+            }
+            // 👇 이미 다른 도전자가 있을 경우
+            if (arenaDetail?.challengerId) {
+                throw new Error("이미 다른 유저가 참가 중입니다.");
+            }
 
             const res = await fetch(`/api/arenas/${arenaDetail?.id}`, {
                 method: "PATCH",
@@ -33,6 +40,7 @@ export default function ArenaDetailRecruiting() {
             }
 
             alert("참가 요청이 접수되었습니다!");
+            window.location.reload();
         } catch (err: unknown) {
             let errorMessage = "알 수 없는 오류가 발생했습니다.";
             if (err instanceof Error) {

--- a/backend/arena/application/usecase/UpdateArenaStatusUsecase.ts
+++ b/backend/arena/application/usecase/UpdateArenaStatusUsecase.ts
@@ -11,6 +11,14 @@ export class UpdateArenaStatusUsecase {
         status: ArenaStatus,
         challengerId?: string
     ): Promise<void> {
+        const arena = await this.arenaRepository.findById(arenaId);
+        if (!arena) {
+            throw new Error("투기장이 존재하지 않습니다.");
+        }
+
+        if (arena.status !== 1 || arena.challengerId) {
+            throw new Error("이미 다른 유저가 참가했습니다.");
+        }
         if (status === 2) {
             if (!challengerId) {
                 throw new Error("challengerId is required for status 2");


### PR DESCRIPTION
## ✨ 작업 개요

투기장 도전 예외처리

## ✅ 상세 내용

-   [x] 내가 작성한 투기장 게시물에 본인이 도전할 수 없도록 수정합니다.
-   [x] 다른사람이 이미 도전한 투기장에 도전할 수 없도록 백엔드 로직을 수정하였습니다.

## 📸 스크린샷 (선택)

## 🧪 확인 사항

-   [x] 정상적으로 동작하는지 직접 테스트해봤나요?
-   [x] 기능 추가/수정 후 UI나 비즈니스 로직에 영향은 없나요?

## 🙏 기타 참고 사항

## 이슈 관리

close #99 
