### PR TITLE
[fix#/111] 로그아웃 시 채팅이 보이지 않는 문제 해결

### DIFF
--- a/app/api/arenas/[id]/chattings/route.ts
+++ b/app/api/arenas/[id]/chattings/route.ts
@@ -144,11 +144,6 @@ export async function GET(
     }
 
     const memberId = await getAuthUserId();
-    if (!memberId) {
-        console.warn(
-            `GET /chattings(${arenaId}): User not authenticated. Cannot fetch sent count.`
-        );
-    }
     const prismaChattingRepository = new PrismaChattingRepository();
     const findChattingUsecase = new FindChattingUsecase(
         prismaChattingRepository

--- a/hooks/useArenaChatManagement.ts
+++ b/hooks/useArenaChatManagement.ts
@@ -51,8 +51,7 @@ export function useArenaChatManagement({
     const fetchChats = useCallback(async () => {
         if (
             typeof arenaId !== "number" ||
-            ![3, 4, 5].includes(arenaDetail?.status || 0) ||
-            !userId
+            ![3, 4, 5].includes(arenaDetail?.status || 0)
         ) {
             setChats([]);
             setRemainingSends(MAX_SEND_COUNT);
@@ -66,9 +65,7 @@ export function useArenaChatManagement({
 
         try {
             // -- 백엔드 GET API 호출 --
-            const res = await fetch(
-                `/api/arenas/${arenaId}/chattings?userId=${userId}`
-            ); // userId 파라미터 예시
+            const res = await fetch(`/api/arenas/${arenaId}/chattings`);
 
             if (!res.ok) {
                 const data = await res.json();
@@ -111,7 +108,10 @@ export function useArenaChatManagement({
         status: status,
         onReceive: useCallback((newChat) => {
             // 새 메시지 수신 시 chats 상태에 추가
-            setChats((prev) => [...prev, newChat]);
+            setChats((prev) => {
+                if (prev.some((chat) => chat.id === newChat.id)) return prev; // 중복 제거
+                return [...prev, newChat];
+            });
         }, []),
     });
 
@@ -200,7 +200,7 @@ export function useArenaChatManagement({
                     await res.json();
                 const newChat = data.newChat;
                 setRemainingSends(data.remainingSends);
-                // setChats((prev) => [...prev, newChat]); // 이거 없으면 안보임
+                setChats((prev) => [...prev, newChat]); // 이거 없으면 안보임
                 socket.emit("chat message", {
                     id: newChat.id, // 백엔드에서 생성된 ID 사용
                     roomId: arenaId.toString(),


### PR DESCRIPTION
## ✨ 작업 개요

로그아웃 시 채팅이 보이지 않는 문제 해결

## ✅ 상세 내용

-   [ ] chatting management hook에서 memberId가 없을 경우 get api를 호출하지 않는 구문을 삭제하였습니다.

## 📸 스크린샷 (선택)

## 🧪 확인 사항

-   [x] 정상적으로 동작하는지 직접 테스트해봤나요?
-   [x] 기능 추가/수정 후 UI나 비즈니스 로직에 영향은 없나요?

## 🙏 기타 참고 사항

## 이슈 관리

close #111 
