### PR TITLE
[feat/#116] 투기장 score 로직 구현

### DIFF
--- a/app/api/arenas/[id]/end/route.ts
+++ b/app/api/arenas/[id]/end/route.ts
@@ -1,0 +1,32 @@
+import { EndArenaUsecase } from "@/backend/arena/application/usecase/EndArenaUsecase";
+import { PrismaArenaRepository } from "@/backend/arena/infra/repositories/prisma/PrismaArenaRepository";
+import { PrismaMemberRepository } from "@/backend/member/infra/repositories/prisma/PrismaMemberRepository";
+import { ApplyArenaScoreUsecase } from "@/backend/score-policy/application/usecase/ApplyArenaScoreUsecase";
+import { ScorePolicy } from "@/backend/score-policy/domain/ScorePolicy";
+import { PrismaScoreRecordRepository } from "@/backend/score-record/infra/repositories/prisma/PrismaScoreRecordRepository";
+import { PrismaVoteRepository } from "@/backend/vote/infra/repositories/prisma/PrismaVoteRepository";
+
+export async function POST(
+    req: Request,
+    context: { params: Promise<{ id: string }> }
+) {
+    const arenaId = Number((await context.params).id);
+
+    const memberRepository = new PrismaMemberRepository();
+    const scoreRecordRepository = new PrismaScoreRecordRepository();
+    const scorePolicy = new ScorePolicy();
+    const arenaRepository = new PrismaArenaRepository();
+    const applyArenaScoreUsecase = new ApplyArenaScoreUsecase(
+        scorePolicy,
+        memberRepository,
+        scoreRecordRepository
+    );
+    const voteRepository = new PrismaVoteRepository();
+    const endArenaUsecase = new EndArenaUsecase(
+        arenaRepository,
+        applyArenaScoreUsecase,
+        voteRepository
+    );
+    await endArenaUsecase.execute(arenaId);
+    return new Response("OK");
+}

--- a/app/api/arenas/[id]/route.ts
+++ b/app/api/arenas/[id]/route.ts
@@ -3,6 +3,10 @@ import { GetArenaDetailUsecase } from "@/backend/arena/application/usecase/GetAr
 import { UpdateArenaStatusUsecase } from "@/backend/arena/application/usecase/UpdateArenaStatusUsecase";
 import { ArenaRepository } from "@/backend/arena/domain/repositories/ArenaRepository";
 import { PrismaArenaRepository } from "@/backend/arena/infra/repositories/prisma/PrismaArenaRepository";
+import { PrismaMemberRepository } from "@/backend/member/infra/repositories/prisma/PrismaMemberRepository";
+import { ApplyArenaScoreUsecase } from "@/backend/score-policy/application/usecase/ApplyArenaScoreUsecase";
+import { ScorePolicy } from "@/backend/score-policy/domain/ScorePolicy";
+import { PrismaScoreRecordRepository } from "@/backend/score-record/infra/repositories/prisma/PrismaScoreRecordRepository";
 import { NextRequest, NextResponse } from "next/server";
 
 type RequestParams = {
@@ -42,10 +46,18 @@ export async function PATCH(
 ) {
     const { status, challengerId } = await req.json();
     const arenaId = Number((await context.params).id);
-
-    const ArenaRepository = new PrismaArenaRepository();
+    const scorePolicy = new ScorePolicy();
+    const memberRepository = new PrismaMemberRepository();
+    const scoreRecordRepository = new PrismaScoreRecordRepository();
+    const applyArenaScoreUsecase = new ApplyArenaScoreUsecase(
+        scorePolicy,
+        memberRepository,
+        scoreRecordRepository
+    );
+    const arenaRepository = new PrismaArenaRepository();
     const updateArenaStatusUsecase = new UpdateArenaStatusUsecase(
-        ArenaRepository
+        arenaRepository,
+        applyArenaScoreUsecase
     );
 
     try {

--- a/backend/arena/application/usecase/EndArenaUsecase.ts
+++ b/backend/arena/application/usecase/EndArenaUsecase.ts
@@ -1,0 +1,71 @@
+import { ArenaRepository } from "@/backend/arena/domain/repositories/ArenaRepository";
+import { ApplyArenaScoreUsecase } from "@/backend/score-policy/application/usecase/ApplyArenaScoreUsecase";
+import { VoteFilter } from "@/backend/vote/domain/repositories/filters/VoteFilter";
+import { VoteRepository } from "@/backend/vote/domain/repositories/VoteRepository";
+
+export class EndArenaUsecase {
+    constructor(
+        private readonly arenaRepository: ArenaRepository,
+        private readonly applyArenaScoreUsecase: ApplyArenaScoreUsecase,
+        private readonly voteRepository: VoteRepository
+    ) {}
+
+    async execute(arenaId: number): Promise<void> {
+        // 1. 투기장 정보, 투표수 조회
+        const arena = await this.arenaRepository.findById(arenaId);
+        const leftVotes = await this.voteRepository.count(
+            new VoteFilter(arenaId, null, arena?.creatorId)
+        );
+
+        const rightVotes = await this.voteRepository.count(
+            new VoteFilter(arenaId, null, arena?.challengerId)
+        );
+        // 2. 승패/무승부/취소 결정
+        let result: "WIN" | "DRAW" | "CANCEL";
+        let winnerId: string | null = null;
+
+        if (!arena?.challengerId) {
+            result = "CANCEL";
+        } else if (leftVotes > rightVotes) {
+            result = "WIN";
+            winnerId = arena?.creatorId || null;
+        } else if (leftVotes < rightVotes) {
+            result = "WIN";
+            winnerId = arena?.challengerId || null;
+        } else {
+            result = "DRAW";
+        }
+
+        // 3. 점수 정책 적용
+        if (result === "CANCEL") {
+            // 둘 다 100점 돌려주기
+            await this.applyArenaScoreUsecase.execute({
+                memberId: arena?.creatorId || "",
+                result: "CANCEL",
+            });
+            await this.applyArenaScoreUsecase.execute({
+                memberId: arena?.challengerId || "",
+                result: "CANCEL",
+            });
+        } else if (result === "DRAW") {
+            await this.applyArenaScoreUsecase.execute({
+                memberId: arena?.creatorId || "",
+                result: "DRAW",
+            });
+            await this.applyArenaScoreUsecase.execute({
+                memberId: arena?.challengerId || "",
+                result: "DRAW",
+            });
+        } else if (result === "WIN" && winnerId) {
+            // 승자에게 WIN, 패자에게 JOIN(패배)
+            const loserId =
+                winnerId === arena?.creatorId
+                    ? arena.challengerId
+                    : arena?.creatorId;
+            await this.applyArenaScoreUsecase.execute({
+                memberId: winnerId,
+                result: "WIN",
+            });
+        }
+    }
+}

--- a/backend/arena/application/usecase/UpdateArenaStatusUsecase.ts
+++ b/backend/arena/application/usecase/UpdateArenaStatusUsecase.ts
@@ -1,10 +1,14 @@
 // backend/arena/application/usecase/UpdateArenaStatusUsecase.ts
 
 import { ArenaRepository } from "@/backend/arena/domain/repositories/ArenaRepository";
+import { ApplyArenaScoreUsecase } from "@/backend/score-policy/application/usecase/ApplyArenaScoreUsecase";
 import { ArenaStatus } from "@/types/arena-status";
 
 export class UpdateArenaStatusUsecase {
-    constructor(private readonly arenaRepository: ArenaRepository) {}
+    constructor(
+        private readonly arenaRepository: ArenaRepository,
+        private readonly applyArenaScoreUsecase: ApplyArenaScoreUsecase
+    ) {}
 
     async execute(
         arenaId: number,
@@ -30,6 +34,10 @@ export class UpdateArenaStatusUsecase {
                 challengerId,
                 status
             );
+            await this.applyArenaScoreUsecase.execute({
+                memberId: challengerId,
+                result: "JOIN",
+            });
         } else {
             await this.arenaRepository.updateStatus(arenaId, status);
         }

--- a/backend/score-policy/domain/ScorePolicy.ts
+++ b/backend/score-policy/domain/ScorePolicy.ts
@@ -13,7 +13,7 @@ export class ScorePolicy {
             case "JOIN":
                 return -100;
             default:
-                return 0;
+                return 0;   
         }
     }
 

--- a/hooks/useArenaAutoStatus.ts
+++ b/hooks/useArenaAutoStatus.ts
@@ -79,7 +79,9 @@ export function useArenaAutoStatus({ arenaList, onStatusUpdate }: Props) {
                 body: JSON.stringify({ status: newStatus, ...extraBody }),
             });
             if (!res.ok) throw new Error("상태 업데이트 실패");
-
+            if (newStatus === 5) {
+                await fetch(`/api/arenas/${arenaId}/end`, { method: "POST" });
+            }
             onStatusUpdate?.(arenaId, newStatus);
         } catch (err) {
             console.error(`아레나 ${arenaId} 상태 업데이트 실패:`, err);

--- a/hooks/useArenaAutoStatusDetail.ts
+++ b/hooks/useArenaAutoStatusDetail.ts
@@ -43,6 +43,11 @@ export function useArenaAutoStatusDetail({
                     body: JSON.stringify({ status: newStatus, ...extraBody }),
                 });
                 if (!res.ok) throw new Error("상태 변경 실패");
+                if (newStatus === 5) {
+                    await fetch(`/api/arenas/${arenaDetail?.id}/end`, {
+                        method: "POST",
+                    });
+                }
                 onStatusUpdate?.(newStatus);
             } catch (err) {
                 console.error("상태 자동 업데이트 실패:", err);


### PR DESCRIPTION
## ✨ 작업 개요

투기장 score 로직 구현

## ✅ 상세 내용

-   [ ] 투기장에 참여할 때, 상태가 5로(종료)변경될 때 유저의 score가 변경되는 기능을 구현하였습니다.

## 📸 스크린샷 (선택)

## 🧪 확인 사항

-   [x] 정상적으로 동작하는지 직접 테스트해봤나요?
-   [x] 기능 추가/수정 후 UI나 비즈니스 로직에 영향은 없나요?

## 🙏 기타 참고 사항

## 이슈 관리

close #116
