### PR TITLE
[Feat/#131] 프로필 페이지-참여 투기장 목록 출력

### DIFF
--- a/app/(base)/profile/components/MyCompletedArenaList.tsx
+++ b/app/(base)/profile/components/MyCompletedArenaList.tsx
@@ -1,0 +1,73 @@
+"use client";
+
+import { useEffect, useRef, useState } from "react";
+import useFetchArenas from "@/hooks/useArenas";
+import useVoteList from "@/hooks/useVoteList";
+import CompleteArenaCard from "@/app/(base)/arenas/components/CompleteArenaCard";
+
+export default function MyCompletedArenaList() {
+    const {
+        arenaListDto,
+        loading: arenaLoading,
+        error: arenaError,
+    } = useFetchArenas({
+        currentPage: 1,
+        status: 5, // 종료된 투기장
+        mine: true,
+        pageSize: 10,
+    });
+
+    const [arenaIdsToFetch, setArenaIdsToFetch] = useState<number[]>([]);
+    const fetchedIdsRef = useRef<string>("");
+
+    useEffect(() => {
+        if (!arenaListDto?.arenas) return;
+
+        const ids = arenaListDto.arenas.map((arena) => arena.id).sort();
+        const idsString = ids.join(",");
+
+        if (fetchedIdsRef.current === idsString) return;
+
+        setArenaIdsToFetch(ids);
+        fetchedIdsRef.current = idsString;
+    }, [arenaListDto?.arenas]);
+
+    const {
+        voteResult,
+        loading: voteLoading,
+        error: voteError,
+    } = useVoteList({ arenaIds: arenaIdsToFetch });
+
+    useEffect(() => {
+        if (!arenaLoading && arenaListDto?.arenas) {
+            console.log("✅ 디버깅: 가져온 arena 개수:", arenaListDto.arenas.length);
+        }
+    }, [arenaLoading, arenaListDto]);
+
+    if (arenaListDto && arenaListDto.arenas) {
+        arenaListDto.arenas.forEach((arena) => {
+            const vote = voteResult.find((v) => v.arenaId === arena.id);
+            arena.leftPercent = vote ? vote.leftPercent : 50;
+        });
+    }
+
+    if (arenaLoading || voteLoading) {
+        return <p className="text-font-200 text-sm">로딩 중입니다...</p>;
+    }
+
+    if (arenaError || voteError) {
+        return <p className="text-red-500 text-sm">투기장 정보를 불러오는 데 실패했습니다.</p>;
+    }
+
+    if (arenaListDto?.arenas.length === 0) {
+        return <p className="text-font-200 text-sm">참여한 종료된 투기장이 없습니다.</p>;
+    }
+
+    return (
+        <div className="flex flex-col items-center gap-6">
+            {arenaListDto?.arenas.map((arena) => (
+                <CompleteArenaCard key={arena.id} {...arena} />
+            ))}
+        </div>
+    );
+}

--- a/app/(base)/profile/components/MyCompletedArenaList.tsx
+++ b/app/(base)/profile/components/MyCompletedArenaList.tsx
@@ -17,7 +17,7 @@ export default function MyCompletedArenaList() {
     } = useFetchArenas({
         currentPage,
         status: 5, // 종료된 투기장
-        mine: false,
+        mine: true,
         pageSize,
     });
 

--- a/app/(base)/profile/components/MyCompletedArenaList.tsx
+++ b/app/(base)/profile/components/MyCompletedArenaList.tsx
@@ -4,17 +4,21 @@ import { useEffect, useRef, useState } from "react";
 import useFetchArenas from "@/hooks/useArenas";
 import useVoteList from "@/hooks/useVoteList";
 import CompleteArenaCard from "@/app/(base)/arenas/components/CompleteArenaCard";
+import Pager from "@/app/components/Pager";
 
 export default function MyCompletedArenaList() {
+    const [currentPage, setCurrentPage] = useState(1);
+    const pageSize = 6;
+
     const {
         arenaListDto,
         loading: arenaLoading,
         error: arenaError,
     } = useFetchArenas({
-        currentPage: 1,
+        currentPage,
         status: 5, // 종료된 투기장
-        mine: true,
-        pageSize: 10,
+        mine: false,
+        pageSize,
     });
 
     const [arenaIdsToFetch, setArenaIdsToFetch] = useState<number[]>([]);
@@ -44,7 +48,8 @@ export default function MyCompletedArenaList() {
         }
     }, [arenaLoading, arenaListDto]);
 
-    if (arenaListDto && arenaListDto.arenas) {
+    // 투표 결과 반영
+    if (arenaListDto?.arenas && voteResult.length > 0) {
         arenaListDto.arenas.forEach((arena) => {
             const vote = voteResult.find((v) => v.arenaId === arena.id);
             arena.leftPercent = vote ? vote.leftPercent : 50;
@@ -59,15 +64,23 @@ export default function MyCompletedArenaList() {
         return <p className="text-red-500 text-sm">투기장 정보를 불러오는 데 실패했습니다.</p>;
     }
 
-    if (arenaListDto?.arenas.length === 0) {
+    if (!arenaListDto || arenaListDto.arenas.length === 0) {
         return <p className="text-font-200 text-sm">참여한 종료된 투기장이 없습니다.</p>;
     }
 
     return (
-        <div className="flex flex-col items-center gap-6">
-            {arenaListDto?.arenas.map((arena) => (
+        <div className="flex flex-col items-center gap-6 w-full">
+            {arenaListDto.arenas.map((arena) => (
                 <CompleteArenaCard key={arena.id} {...arena} />
             ))}
+
+            {/* 페이지네이션 */}
+            <Pager
+                currentPage={arenaListDto.currentPage}
+                endPage={arenaListDto.endPage}
+                pages={arenaListDto.pages}
+                onPageChange={setCurrentPage}
+            />
         </div>
     );
 }

--- a/app/(base)/profile/components/MyDebatingArenaList.tsx
+++ b/app/(base)/profile/components/MyDebatingArenaList.tsx
@@ -1,19 +1,23 @@
 "use client";
 
-import { useEffect } from "react";
+import { useEffect, useState } from "react";
 import useFetchArenas from "@/hooks/useArenas";
 import DebatingArenaCard from "../../arenas/components/DebatingArenaCard";
+import Pager from "@/app/components/Pager";
 
 export default function MyDebatingArenaList() {
+    const [currentPage, setCurrentPage] = useState(1);
+    const pageSize = 6;
+
     const {
         arenaListDto,
         loading,
         error,
     } = useFetchArenas({
-        currentPage: 1,
+        currentPage,
         status: 3, // 토론 중인 투기장
         mine: true,
-        pageSize: 10,
+        pageSize,
     });
 
     useEffect(() => {
@@ -28,16 +32,23 @@ export default function MyDebatingArenaList() {
 
     if (error) {
         return (
-            <p className="text-red-500 text-sm">투기장 정보를 불러오는 데 실패했습니다.</p>
+            <p className="text-red-500 text-sm">
+                투기장 정보를 불러오는 데 실패했습니다.
+            </p>
         );
     }
 
     if (!arenaListDto || arenaListDto.arenas.length === 0) {
-        return <p className="text-font-200 text-sm">진행 중인 투기장이 없습니다.</p>;
+        return (
+            <p className="text-font-200 text-sm">
+                진행 중인 투기장이 없습니다.
+            </p>
+        );
     }
 
     return (
-        <div className="flex flex-col items-center gap-6">
+        <div className="flex flex-col items-center gap-6 w-full">
+            {/* 투기장 카드 목록 */}
             {arenaListDto.arenas.map((arena) => (
                 <DebatingArenaCard
                     key={arena.id}
@@ -50,6 +61,14 @@ export default function MyDebatingArenaList() {
                     debateEndDate={new Date(arena.debateEndDate)}
                 />
             ))}
+
+            {/* 페이지네이션 */}
+            <Pager
+                currentPage={arenaListDto.currentPage}
+                endPage={arenaListDto.endPage}
+                pages={arenaListDto.pages}
+                onPageChange={(page) => setCurrentPage(page)}
+            />
         </div>
     );
 }

--- a/app/(base)/profile/components/MyDebatingArenaList.tsx
+++ b/app/(base)/profile/components/MyDebatingArenaList.tsx
@@ -1,0 +1,55 @@
+"use client";
+
+import { useEffect } from "react";
+import useFetchArenas from "@/hooks/useArenas";
+import DebatingArenaCard from "../../arenas/components/DebatingArenaCard";
+
+export default function MyDebatingArenaList() {
+    const {
+        arenaListDto,
+        loading,
+        error,
+    } = useFetchArenas({
+        currentPage: 1,
+        status: 3, // 토론 중인 투기장
+        mine: true,
+        pageSize: 10,
+    });
+
+    useEffect(() => {
+        if (!loading && arenaListDto?.arenas) {
+            console.log("✅ 진행 중 투기장 개수:", arenaListDto.arenas.length);
+        }
+    }, [loading, arenaListDto]);
+
+    if (loading) {
+        return <p className="text-font-200 text-sm">로딩 중입니다...</p>;
+    }
+
+    if (error) {
+        return (
+            <p className="text-red-500 text-sm">투기장 정보를 불러오는 데 실패했습니다.</p>
+        );
+    }
+
+    if (!arenaListDto || arenaListDto.arenas.length === 0) {
+        return <p className="text-font-200 text-sm">진행 중인 투기장이 없습니다.</p>;
+    }
+
+    return (
+        <div className="flex flex-col items-center gap-6">
+            {arenaListDto.arenas.map((arena) => (
+                <DebatingArenaCard
+                    key={arena.id}
+                    id={arena.id}
+                    title={arena.title}
+                    creatorNickname={arena.creatorNickname}
+                    creatorScore={arena.creatorScore}
+                    challengerNickname={arena.challengerNickname}
+                    challengerScore={arena.challengerScore}
+                    debateEndDate={new Date(arena.debateEndDate)}
+                />
+            ))}
+        </div>
+    );
+}

--- a/app/(base)/profile/components/MyWaitingArenaList.tsx
+++ b/app/(base)/profile/components/MyWaitingArenaList.tsx
@@ -1,19 +1,23 @@
 "use client";
 
-import { useEffect  } from "react";
+import { useEffect, useState } from "react";
 import useFetchArenas from "@/hooks/useArenas";
 import WaitingArenaCard from "../../arenas/components/WaitingArenaCard";
+import Pager from "@/app/components/Pager";
 
 export default function MyWaitingArenaList() {
+    const [currentPage, setCurrentPage] = useState(1);
+    const pageSize = 6;
+
     const {
         arenaListDto,
         loading,
         error,
     } = useFetchArenas({
-        currentPage: 1,
+        currentPage,
         status: 2, // 대기 중인 투기장
-        mine: true, // 내가 만든 또는 참여한
-        pageSize: 10,
+        mine: true,
+        pageSize,
     });
 
     useEffect(() => {
@@ -27,15 +31,22 @@ export default function MyWaitingArenaList() {
     }
 
     if (error) {
-        return <p className="text-red-500 text-sm">투기장 정보를 불러오는 데 실패했습니다.</p>;
+        return (
+            <p className="text-red-500 text-sm">
+                투기장 정보를 불러오는 데 실패했습니다.
+            </p>
+        );
     }
 
     if (!arenaListDto || arenaListDto.arenas.length === 0) {
-        return <p className="text-font-200 text-sm">대기 중인 투기장이 없습니다.</p>;
+        return (
+            <p className="text-font-200 text-sm">대기 중인 투기장이 없습니다.</p>
+        );
     }
 
     return (
-        <div className="flex flex-col items-center gap-6">
+        <div className="flex flex-col items-center gap-6 w-full">
+            {/* 대기 중 투기장 카드 리스트 */}
             {arenaListDto.arenas.map((arena) => (
                 <WaitingArenaCard
                     key={arena.id}
@@ -48,6 +59,14 @@ export default function MyWaitingArenaList() {
                     startDate={new Date(arena.startDate)}
                 />
             ))}
+
+            {/* 페이저 삽입 */}
+            <Pager
+                currentPage={arenaListDto.currentPage}
+                endPage={arenaListDto.endPage}
+                pages={arenaListDto.pages}
+                onPageChange={(page) => setCurrentPage(page)}
+            />
         </div>
     );
 }

--- a/app/(base)/profile/components/MyWaitingArenaList.tsx
+++ b/app/(base)/profile/components/MyWaitingArenaList.tsx
@@ -1,0 +1,53 @@
+"use client";
+
+import { useEffect  } from "react";
+import useFetchArenas from "@/hooks/useArenas";
+import WaitingArenaCard from "../../arenas/components/WaitingArenaCard";
+
+export default function MyWaitingArenaList() {
+    const {
+        arenaListDto,
+        loading,
+        error,
+    } = useFetchArenas({
+        currentPage: 1,
+        status: 2, // 대기 중인 투기장
+        mine: true, // 내가 만든 또는 참여한
+        pageSize: 10,
+    });
+
+    useEffect(() => {
+        if (!loading && arenaListDto?.arenas) {
+            console.log("✅ 대기 중 투기장 개수:", arenaListDto.arenas.length);
+        }
+    }, [loading, arenaListDto]);
+
+    if (loading) {
+        return <p className="text-font-200 text-sm">로딩 중입니다...</p>;
+    }
+
+    if (error) {
+        return <p className="text-red-500 text-sm">투기장 정보를 불러오는 데 실패했습니다.</p>;
+    }
+
+    if (!arenaListDto || arenaListDto.arenas.length === 0) {
+        return <p className="text-font-200 text-sm">대기 중인 투기장이 없습니다.</p>;
+    }
+
+    return (
+        <div className="flex flex-col items-center gap-6">
+            {arenaListDto.arenas.map((arena) => (
+                <WaitingArenaCard
+                    key={arena.id}
+                    id={arena.id}
+                    title={arena.title}
+                    creatorNickname={arena.creatorNickname}
+                    creatorScore={arena.creatorScore}
+                    challengerNickname={arena.challengerNickname}
+                    challengerScore={arena.challengerScore}
+                    startDate={new Date(arena.startDate)}
+                />
+            ))}
+        </div>
+    );
+}

--- a/app/(base)/profile/components/tabs/ProfileArenaTab.tsx
+++ b/app/(base)/profile/components/tabs/ProfileArenaTab.tsx
@@ -1,88 +1,57 @@
 "use client";
 
-import { useEffect, useRef, useState } from "react";
-import useFetchArenas from "@/hooks/useArenas";
-import useVoteList from "@/hooks/useVoteList";
-import CompleteArenaCard from "@/app/(base)/arenas/components/CompleteArenaCard";
+import { useState } from "react";
+import MyWaitingArenaList from "../MyWaitingArenaList";
+import MyDebatingArenaList from "../MyDebatingArenaList";
+import MyCompletedArenaList from "../MyCompletedArenaList";
+
+const TABS = [
+    { key: "waiting", label: "대기 중" },
+    { key: "debating", label: "토론 중" },
+    { key: "completed", label: "종료됨" },
+] as const;
+
+type TabKey = typeof TABS[number]["key"];
 
 export default function ProfileArenaTab() {
-    const {
-        arenaListDto,
-        loading: arenaLoading,
-        error: arenaError,
-    } = useFetchArenas({
-        currentPage: 1,
-        status: 5, // 종료된 투기장
-        mine: false, // 내가 만든 또는 참여한
-        pageSize: 10,
-    });
+    const [activeTab, setActiveTab] = useState<TabKey>("waiting");
 
-    const [arenaIdsToFetch, setArenaIdsToFetch] = useState<number[]>([]);
-    const fetchedIdsRef = useRef<string>("");
-
-    useEffect(() => {
-        if (!arenaListDto?.arenas) return;
-
-        const ids = arenaListDto.arenas.map((arena) => arena.id).sort();
-        const idsString = ids.join(",");
-
-        if (fetchedIdsRef.current === idsString) return;
-
-        setArenaIdsToFetch(ids);
-        fetchedIdsRef.current = idsString;
-    }, [arenaListDto?.arenas]);
-
-    const {
-        voteResult,
-        loading: voteLoading,
-        error: voteError,
-    } = useVoteList({
-        arenaIds: arenaIdsToFetch,
-    });
-
-    useEffect(() => {
-        if (!arenaLoading && arenaListDto?.arenas) {
-            console.log("✅ 디버깅: 가져온 arena 개수:", arenaListDto.arenas.length);
-            console.table(
-                arenaListDto.arenas.map((a) => ({
-                    id: a.id,
-                    title: a.title,
-                    creatorId: a.creatorId,
-                    challengerId: a.challengerId,
-                    status: a.status,
-                }))
-            );
+    const renderContent = () => {
+        switch (activeTab) {
+            case "waiting":
+                return <MyWaitingArenaList />;
+            case "debating":
+                return <MyDebatingArenaList />;
+            case "completed":
+                return <MyCompletedArenaList />;
+            default:
+                return null;
         }
-    }, [arenaLoading, arenaListDto]);
-
-    if (arenaListDto && arenaListDto.arenas) {
-        arenaListDto.arenas.forEach((arena) => {
-            const vote = voteResult.find((v) => v.arenaId === arena.id);
-            arena.leftPercent = vote ? vote.leftPercent : 50;
-        });
-    }
+    };
 
     return (
-        <div className="w-full bg-background-300 p-6 rounded-xl shadow flex flex-col gap-8">
+        <div className="w-full bg-background-300 p-6 rounded-xl shadow flex flex-col gap-6">
             <h2 className="text-lg font-semibold text-body">투기장</h2>
 
-            {arenaLoading || voteLoading ? (
-                <p className="text-font-200 text-sm">로딩 중입니다...</p>
-            ) : arenaError || voteError ? (
-                <p className="text-red-500 text-sm">
-                    투기장 정보를 불러오는 데 실패했습니다.
-                </p>
-            ) : arenaListDto?.arenas.length === 0 ? (
-                <p className="text-font-200 text-sm">
-                    참여한 종료된 투기장이 없습니다.
-                </p>
-            ) : (
-                <div className="flex flex-col items-center gap-6">
-                    {arenaListDto?.arenas.map((arena) => (
-                        <CompleteArenaCard key={arena.id} {...arena} />
-                    ))}
-                </div>
-            )}
+            {/* 탭 메뉴 */}
+            <div className="flex gap-4 border-b border-gray-600 pb-2">
+                {TABS.map((tab) => (
+                    <button
+                        key={tab.key}
+                        onClick={() => setActiveTab(tab.key)}
+                        className={`px-4 py-2 text-sm font-semibold border-b-2 transition-all ${
+                            activeTab === tab.key
+                                ? "border-purple-500 text-purple-500"
+                                : "border-transparent text-gray-400 hover:text-white"
+                        }`}
+                    >
+                        {tab.label}
+                    </button>
+                ))}
+            </div>
+
+            {/* 탭 내용 */}
+            <div>{renderContent()}</div>
         </div>
     );
 }

--- a/app/(base)/profile/components/tabs/ProfileArenaTab.tsx
+++ b/app/(base)/profile/components/tabs/ProfileArenaTab.tsx
@@ -1,10 +1,88 @@
+"use client";
+
+import { useEffect, useRef, useState } from "react";
+import useFetchArenas from "@/hooks/useArenas";
+import useVoteList from "@/hooks/useVoteList";
+import CompleteArenaCard from "@/app/(base)/arenas/components/CompleteArenaCard";
+
 export default function ProfileArenaTab() {
+    const {
+        arenaListDto,
+        loading: arenaLoading,
+        error: arenaError,
+    } = useFetchArenas({
+        currentPage: 1,
+        status: 5, // 종료된 투기장
+        mine: false, // 내가 만든 또는 참여한
+        pageSize: 10,
+    });
+
+    const [arenaIdsToFetch, setArenaIdsToFetch] = useState<number[]>([]);
+    const fetchedIdsRef = useRef<string>("");
+
+    useEffect(() => {
+        if (!arenaListDto?.arenas) return;
+
+        const ids = arenaListDto.arenas.map((arena) => arena.id).sort();
+        const idsString = ids.join(",");
+
+        if (fetchedIdsRef.current === idsString) return;
+
+        setArenaIdsToFetch(ids);
+        fetchedIdsRef.current = idsString;
+    }, [arenaListDto?.arenas]);
+
+    const {
+        voteResult,
+        loading: voteLoading,
+        error: voteError,
+    } = useVoteList({
+        arenaIds: arenaIdsToFetch,
+    });
+
+    useEffect(() => {
+        if (!arenaLoading && arenaListDto?.arenas) {
+            console.log("✅ 디버깅: 가져온 arena 개수:", arenaListDto.arenas.length);
+            console.table(
+                arenaListDto.arenas.map((a) => ({
+                    id: a.id,
+                    title: a.title,
+                    creatorId: a.creatorId,
+                    challengerId: a.challengerId,
+                    status: a.status,
+                }))
+            );
+        }
+    }, [arenaLoading, arenaListDto]);
+
+    if (arenaListDto && arenaListDto.arenas) {
+        arenaListDto.arenas.forEach((arena) => {
+            const vote = voteResult.find((v) => v.arenaId === arena.id);
+            arena.leftPercent = vote ? vote.leftPercent : 50;
+        });
+    }
+
     return (
         <div className="w-full bg-background-300 p-6 rounded-xl shadow flex flex-col gap-8">
             <h2 className="text-lg font-semibold text-body">투기장</h2>
-            <p className="text-font-200 text-sm">
-                투기장 정보는 현재 준비 중입니다. 곧 업데이트될 예정입니다.
-            </p>
+
+            {arenaLoading || voteLoading ? (
+                <p className="text-font-200 text-sm">로딩 중입니다...</p>
+            ) : arenaError || voteError ? (
+                <p className="text-red-500 text-sm">
+                    투기장 정보를 불러오는 데 실패했습니다.
+                </p>
+            ) : arenaListDto?.arenas.length === 0 ? (
+                <p className="text-font-200 text-sm">
+                    참여한 종료된 투기장이 없습니다.
+                </p>
+            ) : (
+                <div className="flex flex-col items-center gap-6">
+                    {arenaListDto?.arenas.map((arena) => (
+                        <CompleteArenaCard key={arena.id} {...arena} />
+                    ))}
+                </div>
+            )}
         </div>
     );
 }

--- a/app/(base)/profile/components/tabs/ProfileArenaTab.tsx
+++ b/app/(base)/profile/components/tabs/ProfileArenaTab.tsx
@@ -1,0 +1,10 @@
+export default function ProfileArenaTab() {
+    return (
+        <div className="w-full bg-background-300 p-6 rounded-xl shadow flex flex-col gap-8">
+            <h2 className="text-lg font-semibold text-body">투기장</h2>
+            <p className="text-font-200 text-sm">
+                투기장 정보는 현재 준비 중입니다. 곧 업데이트될 예정입니다.
+            </p>
+        </div>
+    );
+}

--- a/app/(base)/profile/components/tabs/ProfilePointHistoryTab.tsx
+++ b/app/(base)/profile/components/tabs/ProfilePointHistoryTab.tsx
@@ -48,7 +48,7 @@ export default function ProfilePointHistoryTab() {
             <h2 className="text-lg font-semibold text-body">포인트 히스토리</h2>
 
             {records.length === 0 ? (
-                <p className="text-font-100">포인트 기록이 없습니다.</p>
+                <p className="text-font-200 text-sm">포인트 기록이 없습니다.</p>
             ) : (
                 <>
                     <div className="flex flex-col gap-4">

--- a/app/(base)/profile/page.tsx
+++ b/app/(base)/profile/page.tsx
@@ -10,6 +10,7 @@ import ProfileInfoTab from "./components/tabs/ProfileInfoTab";
 import ProfileReviewTab from "./components/tabs/ProfileReviewTab";
 import ProfileWishlistTab from "./components/tabs/ProfileWishlistTab";
 import ProfilePointHistoryTab from "./components/tabs/ProfilePointHistoryTab";
+import ProfileArenaTab from "./components/tabs/ProfileArenaTab";
 
 // ✅ 위시리스트 게임 카드용 타입
 type WishlistGame = {
@@ -128,6 +129,9 @@ export default function ProfilePage() {
                     )}
                     {activeTab === "score-history" && !loading && (
                         <ProfilePointHistoryTab />
+                    )}
+                    {activeTab === "arena" && !loading && (
+                        <ProfileArenaTab />
                     )}
                 </div>
             </div>


### PR DESCRIPTION
## ✨ 작업 개요

* 참여 투기장 목록 출력

## ✅ 상세 내용

-   [x] 대기중, 토론중, 종료된 투기장 리스트 호출
-   [x] 각 토론 상태에 따라 탭으로 나눠서 호출

## 📸 스크린샷 (선택)

* 예시화면

![image](https://github.com/user-attachments/assets/4e71a93b-aea4-4683-a87d-9cd7b12b1984)


## 🧪 확인 사항

-   [x] 정상적으로 동작하는지 직접 테스트해봤나요?
-   [x] 기능 추가/수정 후 UI나 비즈니스 로직에 영향은 없나요?
-   [x] PR 리뷰어가 중점적으로 확인하면 좋을 부분은?

## 🙏 기타 참고 사항

* 현재 mine값이 true 일때는 리스트를 못가져 오고 있더라고요 이부분 확인해주세요

## 이슈 관리

close #131 
