### PR TITLE
[style/#158] 로딩 애니메이션 추가

### DIFF
--- a/.github/workflows/deploy-on-ubuntu-server.yml
+++ b/.github/workflows/deploy-on-ubuntu-server.yml
@@ -15,7 +15,7 @@ jobs:
 
         steps:
             - name: Build Next.js Project
-              run: echo "Build Next.js Project"
+              run: npx prisma generate
 
     # 두번째 단계: 테스트
     test:

--- a/app/(auth)/sign-up/page.tsx
+++ b/app/(auth)/sign-up/page.tsx
@@ -6,22 +6,33 @@ import StepThemes from "../components/StepThemes";
 import StepPlatforms from "../components/StepPlatforms";
 import StepProfile from "../components/StepProfile";
 import { useRouter } from "next/navigation";
+import Toast from "@/app/components/Toast";
 
 export default function Register() {
     const [step, setStep] = useState(1);
     const router = useRouter();
 
+    const [showToast, setShowToast] = useState(false);
+    const [toastMessage, setToastMessage] = useState("");
+    const [toastStatus, setToastStatus] = useState<
+        "success" | "error" | "info"
+    >("success");
+
     const nextStep = () => setStep((prev) => Math.min(prev + 1, 5));
     const prevStep = () => setStep((prev) => Math.max(prev - 1, 1));
 
     const handleSubmit = () => {
-        alert("회원가입이 완료되었습니다!");
-        router.push("/log-in");
+        setToastStatus("success");
+        setToastMessage("회원가입이 완료되었습니다!");
+        setShowToast(true);
+
+        setTimeout(() => {
+            router.push("/log-in");
+        }, 2000); // 토스트 표시 후 이동
     };
 
     return (
         <div className="w-full max-w-xl mx-auto min-h-screen flex flex-col px-4 py-8 text-white">
-            {/* 진행도 표시 (상단으로 이동) */}
             <h2 className="text-h2 font-bold mb-6">회원 정보를 입력해주세요</h2>
             <div className="w-full mb-8">
                 <div className="text-sm text-right mb-1">{step}/4 진행중</div>
@@ -33,13 +44,20 @@ export default function Register() {
                 </div>
             </div>
 
-            {/* 스텝별 컴포넌트 렌더링 */}
+            {/* 스텝 컴포넌트 */}
             {step === 1 && <StepProfile onNext={nextStep} />}
             {step === 2 && <StepGenres onNext={nextStep} onBack={prevStep} />}
             {step === 3 && <StepThemes onNext={nextStep} onBack={prevStep} />}
             {step === 4 && (
                 <StepPlatforms onBack={prevStep} onSubmit={handleSubmit} />
             )}
+
+            {/* ✅ 토스트 메시지 컴포넌트 */}
+            <Toast
+                show={showToast}
+                status={toastStatus}
+                message={toastMessage}
+            />
         </div>
     );
 }

--- a/app/(base)/arenas/ArenaPage.tsx
+++ b/app/(base)/arenas/ArenaPage.tsx
@@ -1,7 +1,7 @@
-// app/(base)/arenas/ArenaPage.tsx
 "use client";
 
 import { useSearchParams } from "next/navigation";
+import { useEffect, useState, useCallback } from "react";
 import ArenaPageHeader from "./components/ArenaPageHeader";
 import CompleteArenaSection from "./components/CompleteArenaSection";
 import DebatingArenaSection from "./components/DebatingArenaSection";
@@ -10,41 +10,70 @@ import VotingArenaSection from "./components/VotingArenaSection";
 import WaitingArenaSection from "./components/WaitingArenaSection";
 import SelectedArenaSection from "./components/SelectedArenaSection";
 import Modals from "@/app/components/Modals";
+import { useLoadingStore } from "@/stores/loadingStore";
 
 export default function ArenaPage() {
-    const searchParams = useSearchParams();
-    const currentPage: number = Number(searchParams.get("currentPage") || "1");
-    const status: number | null = Number(searchParams.get("status")) || null;
+  const searchParams = useSearchParams();
+  const currentPage: number = Number(searchParams.get("currentPage") || "1");
+  const status: number | null = Number(searchParams.get("status")) || null;
 
-    return (
-        <div className="min-h-screen bg-background-400 text-font-100 py-12 space-y-10">
-            <ArenaPageHeader />
-            <Modals />
-            {(() => {
-                switch (status) {
-                    case 1:
-                    case 2:
-                    case 3:
-                    case 4:
-                    case 5:
-                        return (
-                            <SelectedArenaSection
-                                status={status}
-                                currentPage={currentPage}
-                            />
-                        );
-                    default:
-                        return (
-                            <>
-                                <VotingArenaSection />
-                                <RecruitingArenaSection />
-                                <DebatingArenaSection />
-                                <CompleteArenaSection />
-                                <WaitingArenaSection />
-                            </>
-                        );
-                }
-            })()}
-        </div>
-    );
+  const { setLoading } = useLoadingStore();
+  const [doneSections, setDoneSections] = useState(0);
+
+  const totalSections = 5;
+
+  useEffect(() => {
+    setLoading(true);
+    setDoneSections(0);
+  }, [status, currentPage, setLoading]);
+
+  useEffect(() => {
+    if (!status && doneSections >= totalSections) {
+      setLoading(false);
+    }
+  }, [doneSections, status, setLoading]);
+
+  const handleSectionLoaded = useCallback(() => {
+    setDoneSections((prev) => {
+      if (prev >= totalSections) return prev; // 무한루프 방지
+      return prev + 1;
+    });
+  }, [totalSections]);
+
+  const handleSelectedLoaded = useCallback(() => {
+    setLoading(false);
+  }, [setLoading]);
+
+  return (
+    <div className="min-h-screen bg-background-400 text-font-100 py-12 space-y-10">
+      <ArenaPageHeader />
+      <Modals />
+      {(() => {
+        switch (status) {
+          case 1:
+          case 2:
+          case 3:
+          case 4:
+          case 5:
+            return (
+              <SelectedArenaSection
+                status={status}
+                currentPage={currentPage}
+                onLoaded={handleSelectedLoaded}
+              />
+            );
+          default:
+            return (
+              <>
+                <VotingArenaSection onLoaded={handleSectionLoaded} />
+                <RecruitingArenaSection onLoaded={handleSectionLoaded} />
+                <DebatingArenaSection onLoaded={handleSectionLoaded} />
+                <CompleteArenaSection onLoaded={handleSectionLoaded} />
+                <WaitingArenaSection onLoaded={handleSectionLoaded} />
+              </>
+            );
+        }
+      })()}
+    </div>
+  );
 }

--- a/app/(base)/arenas/[id]/page.tsx
+++ b/app/(base)/arenas/[id]/page.tsx
@@ -9,17 +9,22 @@ import useArenaStore from "@/stores/useArenaStore";
 import ArenaDetailContainer from "./components/ArenaDetailContainer";
 import { useArenaAutoStatusDetail } from "@/hooks/useArenaAutoStatusDetail";
 import { useParams } from "next/navigation";
+import { useLoadingStore } from "@/stores/loadingStore"; // ✅ 전역 로딩 스토어 가져오기
 
 export default function ArenaDetailPage() {
     const setGlobalArenaData = useArenaStore((state) => state.setArenaData);
     const clearGlobalArenaData = useArenaStore((state) => state.clearArenaData);
+    const { setLoading } = useLoadingStore(); // ✅ 전역 로딩 제어 함수
     const idParams = useParams().id;
     const arenaId = Number(idParams);
+
     useArenaAutoStatusDetail({
         onStatusUpdate: () => {},
     });
+
     useEffect(() => {
         const fetchArenaDetail = async () => {
+            setLoading(true); // ✅ 로딩 시작
             try {
                 const res = await fetch(`/api/arenas/${arenaId}`, {
                     method: "GET",
@@ -34,14 +39,18 @@ export default function ArenaDetailPage() {
                 setGlobalArenaData(data);
             } catch (error) {
                 console.error("Error fetching arena detail:", error);
+            } finally {
+                setLoading(false); // ✅ 로딩 종료
             }
         };
 
         fetchArenaDetail();
+
         return () => {
             clearGlobalArenaData();
         };
-    }, [arenaId, setGlobalArenaData, clearGlobalArenaData]);
+    }, [arenaId, setGlobalArenaData, clearGlobalArenaData, setLoading]);
+
     return (
         <div>
             <div className="flex px-16 py-16 gap-8">

--- a/app/(base)/arenas/components/DebatingArenaSection.tsx
+++ b/app/(base)/arenas/components/DebatingArenaSection.tsx
@@ -5,8 +5,13 @@ import ArenaSectionHeader from "./ArenaSectionHeader";
 import DebatingArenaCard from "./DebatingArenaCard";
 import { useArenaAutoStatus } from "@/hooks/useArenaAutoStatus";
 import { GetSectionTitle } from "@/utils/GetSectionTitle";
+import { useEffect } from "react";
 
-export default function DebatingArenaSection() {
+interface Props {
+    onLoaded?: () => void; // ✅ 상위로 로딩 완료 알림
+}
+
+export default function DebatingArenaSection({ onLoaded }: Props) {
     const status: number = 3;
 
     const { arenaListDto, loading, error } = useArenas({
@@ -19,14 +24,19 @@ export default function DebatingArenaSection() {
     useArenaAutoStatus({
         arenaList: arenaListDto?.arenas || [],
         onStatusUpdate: (arenaId, newStatus) => {
-            // 선택사항: 콘솔 로깅 또는 새로고침 로직 삽입 가능
             console.log(
                 `Arena ${arenaId}가 상태 ${newStatus}로 전이되었습니다.`
             );
-            // 필요 시 리패칭 로직 넣을 수 있음
         },
     });
-    // TODO: use Loading Page
+
+    // ✅ 로딩이 끝나면 onLoaded 콜백 실행
+    useEffect(() => {
+        if (!loading) {
+            onLoaded?.();
+        }
+    }, [loading, onLoaded]);
+
     if (loading) {
         return (
             <div className="col-span-3 text-center text-gray-400">
@@ -34,12 +44,11 @@ export default function DebatingArenaSection() {
             </div>
         );
     }
-    // TODO: use Error Page
+
     if (error) {
         return (
             <div className="col-span-3 text-center text-red-500">
-                투기장 정보를 불러오는 데 실패했습니다. 나중에 다시
-                시도해주세요.
+                투기장 정보를 불러오는 데 실패했습니다. 나중에 다시 시도해주세요.
             </div>
         );
     }
@@ -53,7 +62,7 @@ export default function DebatingArenaSection() {
                         현재 {GetSectionTitle(status)}이 없습니다.
                     </div>
                 ) : (
-                    arenaListDto!.arenas.map((arena) => (
+                    arenaListDto?.arenas.map((arena) => (
                         <DebatingArenaCard
                             key={arena.id}
                             {...arena}

--- a/app/(base)/arenas/components/RecruitingArenaSection.tsx
+++ b/app/(base)/arenas/components/RecruitingArenaSection.tsx
@@ -5,8 +5,13 @@ import { GetSectionTitle } from "@/utils/GetSectionTitle";
 import ArenaSectionHeader from "./ArenaSectionHeader";
 import RecruitingArenaCard from "./RecruitingArenaCard";
 import useArenas from "@/hooks/useArenas";
+import { useEffect } from "react";
 
-export default function RecruitingArenaSection() {
+interface Props {
+    onLoaded?: () => void; // ✅ 로딩 완료 시 호출되는 콜백
+}
+
+export default function RecruitingArenaSection({ onLoaded }: Props) {
     const status: number = 1;
 
     const { arenaListDto, loading, error } = useArenas({
@@ -19,14 +24,19 @@ export default function RecruitingArenaSection() {
     useArenaAutoStatus({
         arenaList: arenaListDto?.arenas || [],
         onStatusUpdate: (arenaId, newStatus) => {
-            // 선택사항: 콘솔 로깅 또는 새로고침 로직 삽입 가능
             console.log(
                 `Arena ${arenaId}가 상태 ${newStatus}로 전이되었습니다.`
             );
-            // 필요 시 리패칭 로직 넣을 수 있음
         },
     });
-    // TODO: use Loading Page
+
+    // ✅ 로딩이 끝났을 때 onLoaded 호출
+    useEffect(() => {
+        if (!loading) {
+            onLoaded?.();
+        }
+    }, [loading, onLoaded]);
+
     if (loading) {
         return (
             <div className="col-span-3 text-center text-gray-400">
@@ -34,12 +44,11 @@ export default function RecruitingArenaSection() {
             </div>
         );
     }
-    // TODO: use Error Page
+
     if (error) {
         return (
             <div className="col-span-3 text-center text-red-500">
-                투기장 정보를 불러오는 데 실패했습니다. 나중에 다시
-                시도해주세요.
+                투기장 정보를 불러오는 데 실패했습니다. 나중에 다시 시도해주세요.
             </div>
         );
     }

--- a/app/(base)/arenas/components/WaitingArenaSection.tsx
+++ b/app/(base)/arenas/components/WaitingArenaSection.tsx
@@ -5,8 +5,13 @@ import ArenaSectionHeader from "./ArenaSectionHeader";
 import WaitingArenaCard from "./WaitingArenaCard";
 import { useArenaAutoStatus } from "@/hooks/useArenaAutoStatus";
 import { GetSectionTitle } from "@/utils/GetSectionTitle";
+import { useEffect } from "react";
 
-export default function WaitingArenaSection() {
+interface Props {
+    onLoaded?: () => void; // ✅ 상위에서 로딩 완료 알림을 받을 콜백
+}
+
+export default function WaitingArenaSection({ onLoaded }: Props) {
     const status: number = 2;
 
     const { arenaListDto, loading, error } = useArenas({
@@ -19,14 +24,19 @@ export default function WaitingArenaSection() {
     useArenaAutoStatus({
         arenaList: arenaListDto?.arenas || [],
         onStatusUpdate: (arenaId, newStatus) => {
-            // 선택사항: 콘솔 로깅 또는 새로고침 로직 삽입 가능
             console.log(
                 `Arena ${arenaId}가 상태 ${newStatus}로 전이되었습니다.`
             );
-            // 필요 시 리패칭 로직 넣을 수 있음
         },
     });
-    // TODO: use Loading Page
+
+    // ✅ 데이터 패칭 완료되면 상위에 알림
+    useEffect(() => {
+        if (!loading) {
+            onLoaded?.();
+        }
+    }, [loading, onLoaded]);
+
     if (loading) {
         return (
             <div className="col-span-3 text-center text-gray-400">
@@ -34,15 +44,15 @@ export default function WaitingArenaSection() {
             </div>
         );
     }
-    // TODO: use Error Page
+
     if (error) {
         return (
             <div className="col-span-3 text-center text-red-500">
-                투기장 정보를 불러오는 데 실패했습니다. 나중에 다시
-                시도해주세요.
+                투기장 정보를 불러오는 데 실패했습니다. 나중에 다시 시도해주세요.
             </div>
         );
     }
+
     return (
         <div>
             <ArenaSectionHeader status={2} />

--- a/app/(base)/profile/components/MyDebatingArenaList.tsx
+++ b/app/(base)/profile/components/MyDebatingArenaList.tsx
@@ -4,10 +4,12 @@ import { useEffect, useState } from "react";
 import useFetchArenas from "@/hooks/useArenas";
 import DebatingArenaCard from "../../arenas/components/DebatingArenaCard";
 import Pager from "@/app/components/Pager";
+import { useLoadingStore } from "@/stores/loadingStore"; // ✅ 추가
 
 export default function MyDebatingArenaList() {
     const [currentPage, setCurrentPage] = useState(1);
     const pageSize = 6;
+    const { setLoading } = useLoadingStore(); // ✅ 전역 로딩 제어 가져오기
 
     const {
         arenaListDto,
@@ -19,6 +21,11 @@ export default function MyDebatingArenaList() {
         mine: true,
         pageSize,
     });
+
+    // ✅ 전역 로딩 상태 동기화
+    useEffect(() => {
+        setLoading(loading);
+    }, [loading, setLoading]);
 
     useEffect(() => {
         if (!loading && arenaListDto?.arenas) {

--- a/app/(base)/profile/components/tabs/ProfilePointHistoryTab.tsx
+++ b/app/(base)/profile/components/tabs/ProfilePointHistoryTab.tsx
@@ -3,6 +3,7 @@
 import { useEffect, useState } from "react";
 import PointHistoryCard from "../PointHistoryCard";
 import Pager from "@/app/components/Pager";
+import { useLoadingStore } from "@/stores/loadingStore"; // ✅ 전역 로딩 상태 사용
 
 interface ScoreRecord {
     actualScore: number;
@@ -15,6 +16,7 @@ interface ScoreRecord {
 }
 
 export default function ProfilePointHistoryTab() {
+    const { setLoading } = useLoadingStore(); // ✅ 전역 로딩 제어
     const [records, setRecords] = useState<ScoreRecord[]>([]);
     const [currentPage, setCurrentPage] = useState(1);
     const itemsPerPage = 6;
@@ -30,6 +32,8 @@ export default function ProfilePointHistoryTab() {
 
     useEffect(() => {
         const fetchRecords = async () => {
+            setLoading(true); // ✅ 로딩 시작
+
             try {
                 const res = await fetch("/api/member/scores");
                 if (!res.ok) throw new Error("스코어 기록 조회 실패");
@@ -37,11 +41,13 @@ export default function ProfilePointHistoryTab() {
                 setRecords(data);
             } catch (err) {
                 console.error("🔥 포인트 히스토리 조회 실패", err);
+            } finally {
+                setLoading(false); // ✅ 로딩 종료
             }
         };
 
         fetchRecords();
-    }, []);
+    }, [setLoading]);
 
     return (
         <div className="w-full bg-background-300 p-6 rounded-xl shadow flex flex-col gap-8">
@@ -64,7 +70,6 @@ export default function ProfilePointHistoryTab() {
                         ))}
                     </div>
 
-                    {/* 총 페이지 수가 1보다 많을 때만 Pager 출력 */}
                     {endPage > 1 && (
                         <Pager
                             currentPage={currentPage}

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
     "scripts": {
         "dev": "next dev --turbopack",
         "build": "next build",
-        "start": "next start",
+        "start": "next start -p 3035",
         "lint": "next lint"
     },
     "dependencies": {


### PR DESCRIPTION
## ✨ 작업 개요

* 로딩 애니메이션 다른 페이지에 추가

## ✅ 상세 내용

-   [x] 프로필 페이지에 로딩 애니메이션 추가
-   [x] 투기장 탐색 페이지에 로딩 애니메이션 추가(각 세션에서 onLoading() 전달 받아서 탐색 페이지에서 확인)
-   [x] 투기장 상세 페이지에 로딩 애니메이션 추가

## 📸 스크린샷 (선택)

## 🧪 확인 사항

-   [x] 정상적으로 동작하는지 직접 테스트해봤나요?
-   [x] 기능 추가/수정 후 UI나 비즈니스 로직에 영향은 없나요?
-   [x] PR 리뷰어가 중점적으로 확인하면 좋을 부분은?

## 🙏 기타 참고 사항
GitHub Actions 관련 npm run script 변경점 package.json에 반영해뒀습니다.
GitHub Actions 중 build step에서 npx prisma generate을 실행하도록 변경했습니다.

## 이슈 관리

close #158
