### PR TITLE
[fix/#171] 투기장 상태변경 KTC -> UTC 기준으로 수정

### DIFF
--- a/hooks/useArenaAutoStatus.ts
+++ b/hooks/useArenaAutoStatus.ts
@@ -12,7 +12,7 @@ export function useArenaAutoStatus({ arenaList, onStatusUpdate }: Props) {
     const timers = useRef<Record<number, NodeJS.Timeout>>({}); // arenaId -> timeout
 
     useEffect(() => {
-        const now = Date.now();
+        const now = new Date().getTime();
 
         arenaList.forEach((arena) => {
             const {

--- a/hooks/useArenaAutoStatusDetail.ts
+++ b/hooks/useArenaAutoStatusDetail.ts
@@ -15,7 +15,7 @@ export function useArenaAutoStatusDetail({
     useEffect(() => {
         let timer: NodeJS.Timeout | null = null;
 
-        const now = Date.now();
+        const now = new Date().getTime();
 
         const scheduleUpdate = (
             targetTime: Date,


### PR DESCRIPTION
## ✨ 작업 개요

투기장 상태변경 KTC -> UTC 기준으로 수정

## ✅ 상세 내용

-   [x] 투기장 상태를 변경할 때 UTC 기준으로 변경되도록 수정하였습니다.
- 
## 📸 스크린샷 (선택)

## 🧪 확인 사항

-   [x] 정상적으로 동작하는지 직접 테스트해봤나요?
-   [x] 기능 추가/수정 후 UI나 비즈니스 로직에 영향은 없나요?

## 🙏 기타 참고 사항

## 이슈 관리

close #171 
