### PR TITLE
[fix/#173] 투기장 상태변경 UTC -> KST 기준으로 재수정

### DIFF
--- a/app/(base)/arenas/[id]/components/ArenaDetailInfo.tsx
+++ b/app/(base)/arenas/[id]/components/ArenaDetailInfo.tsx
@@ -45,7 +45,27 @@ export default function ArenaDetailInfo() {
                             진행 일정
                         </h3>
                         <p className="text-caption text-font-100">
-                            {arenaDetail?.startDate} ~{arenaDetail?.endChatting}
+                            {arenaDetail?.startDate.toLocaleDateString(
+                                "ko-KR",
+                                {
+                                    year: "numeric",
+                                    month: "long",
+                                    day: "numeric",
+                                    hour: "2-digit",
+                                    minute: "2-digit",
+                                }
+                            )}{" "}
+                            ~{" "}
+                            {arenaDetail?.endChatting.toLocaleDateString(
+                                "ko-KR",
+                                {
+                                    year: "numeric",
+                                    month: "long",
+                                    day: "numeric",
+                                    hour: "2-digit",
+                                    minute: "2-digit",
+                                }
+                            )}
                         </p>
                     </div>
                 </div>
@@ -63,7 +83,24 @@ export default function ArenaDetailInfo() {
                             투표 시간
                         </h3>
                         <p className="text-caption text-font-100">
-                            {arenaDetail?.endChatting} ~{arenaDetail?.endVote}
+                            {arenaDetail?.endChatting.toLocaleDateString(
+                                "ko-KR",
+                                {
+                                    year: "numeric",
+                                    month: "long",
+                                    day: "numeric",
+                                    hour: "2-digit",
+                                    minute: "2-digit",
+                                }
+                            )}{" "}
+                            ~{" "}
+                            {arenaDetail?.endVote.toLocaleDateString("ko-KR", {
+                                year: "numeric",
+                                month: "long",
+                                day: "numeric",
+                                hour: "2-digit",
+                                minute: "2-digit",
+                            })}
                         </p>
                     </div>
                 </div>

--- a/app/(base)/arenas/[id]/page.tsx
+++ b/app/(base)/arenas/[id]/page.tsx
@@ -36,7 +36,23 @@ export default function ArenaDetailPage() {
                 }
 
                 const data: ArenaDetailDto = await res.json();
-                setGlobalArenaData(data);
+                setGlobalArenaData(
+                    new ArenaDetailDto(
+                        data.id,
+                        data.creatorId,
+                        data.creatorName,
+                        data.creatorScore,
+                        data.challengerId,
+                        data.challengerName,
+                        data.challengerScore,
+                        data.title,
+                        data.description,
+                        new Date(data.startDate),
+                        new Date(data.endChatting),
+                        new Date(data.endVote),
+                        data.status
+                    )
+                );
             } catch (error) {
                 console.error("Error fetching arena detail:", error);
             } finally {

--- a/backend/arena/application/usecase/GetArenaDetailUsecase.ts
+++ b/backend/arena/application/usecase/GetArenaDetailUsecase.ts
@@ -2,7 +2,6 @@
 
 import { ArenaRepository } from "@/backend/arena/domain/repositories/ArenaRepository";
 import { ArenaDetailDto } from "@/backend/arena/application/usecase/dto/ArenaDetailDto";
-import dayjs from "dayjs";
 import { MemberRepository } from "@/backend/member/domain/repositories/MemberRepository";
 import { ArenaStatus } from "@/types/arena-status";
 export class GetArenaDetailUsecase {
@@ -25,14 +24,9 @@ export class GetArenaDetailUsecase {
         const challengerScore = await this.memberRepository.findById(
             ArenaDetail.challengerId || ""
         );
-        const startDateObj = dayjs(ArenaDetail.startDate);
-        const endChattingObj = startDateObj.add(30, "minute");
-        const endVoteObj = endChattingObj.add(24, "hour");
-
-        // 끝 시간도 같은 형식으로 문자열로
-        const StartDate = startDateObj.format("YYYY-MM-DD HH:mm:ss");
-        const endChatting = endChattingObj.format("YYYY-MM-DD HH:mm:ss");
-        const endVote = endVoteObj.format("YYYY-MM-DD HH:mm:ss");
+        const startDate = ArenaDetail.startDate;
+        const endChatting = new Date(startDate.getTime() + 30 * 60 * 1000);
+        const endVote = new Date(endChatting.getTime() + 24 * 60 * 60 * 1000);
 
         return new ArenaDetailDto(
             ArenaDetail.id,
@@ -44,7 +38,7 @@ export class GetArenaDetailUsecase {
             challengerScore?.score || 0,
             ArenaDetail.title,
             ArenaDetail.description,
-            StartDate,
+            ArenaDetail.startDate,
             endChatting,
             endVote,
             ArenaDetail.status as ArenaStatus

--- a/backend/arena/application/usecase/dto/ArenaDetailDto.ts
+++ b/backend/arena/application/usecase/dto/ArenaDetailDto.ts
@@ -11,9 +11,9 @@ export class ArenaDetailDto {
         public challengerScore: number | null,
         public title: string,
         public description: string,
-        public startDate: string,
-        public endChatting: string,
-        public endVote: string,
+        public startDate: Date,
+        public endChatting: Date,
+        public endVote: Date,
         public status: ArenaStatus
     ) {}
 }


### PR DESCRIPTION
## ✨ 작업 개요

투기장 상태변경 UTC -> KST 기준으로 재수정

## ✅ 상세 내용

-   [x] 투기장 상태변경 UTC -> KST 기준으로 재수정하였습니다.

## 📸 스크린샷 (선택)

## 🧪 확인 사항

-   [x] 정상적으로 동작하는지 직접 테스트해봤나요?
-   [x] 기능 추가/수정 후 UI나 비즈니스 로직에 영향은 없나요?

## 🙏 기타 참고 사항

## 이슈 관리

close #173
