### PR TITLE
[chore#177] 회원가입시 프로필이미지 절대경로로 수정

### DIFF
--- a/app/(base)/games/[gameId]/components/CommentCard.tsx
+++ b/app/(base)/games/[gameId]/components/CommentCard.tsx
@@ -165,7 +165,7 @@ export default function CommentCard({
                 <div className="flex gap-2 items-start">
                     <div className="w-[44px] h-[44px] rounded-full border border-line-100 overflow-hidden flex-shrink-0">
                         <Image
-                            src={profileImage || "/placeholder.svg"}
+                            src={profileImage}
                             alt="profile"
                             width={44}
                             height={44}

--- a/backend/member/infra/repositories/prisma/PrismaMemberRepository.ts
+++ b/backend/member/infra/repositories/prisma/PrismaMemberRepository.ts
@@ -33,6 +33,7 @@ export class PrismaMemberRepository implements MemberRepository {
                 ),
                 isMale: data.gender === "M",
                 imageUrl: "/icons/arena.svg",
+
                 score: 500,
             },
         });


### PR DESCRIPTION
## ✨ 작업 개요
회원가입시 프로필이미지 절대경로로 수정


## ✅ 상세 내용

-   [ ] 회원가입시 프로필이미지 절대경로로 수정 댓글카드에서 기본이미지 보이게


## 📸 스크린샷 (선택)

## 🧪 확인 사항

-   [x] 정상적으로 동작하는지 직접 테스트해봤나요?
-   [ ] 기능 추가/수정 후 UI나 비즈니스 로직에 영향은 없나요?
-   [ ] PR 리뷰어가 중점적으로 확인하면 좋을 부분은?

## 🙏 기타 참고 사항

## 이슈 관리

close #177 
