### PR TITLE
[refactor/#195] 백엔드 리펙토링 투기장 탐색 페이지에 적용

### DIFF
--- a/app/(base)/arenas/ArenaPage.tsx
+++ b/app/(base)/arenas/ArenaPage.tsx
@@ -45,7 +45,7 @@ export default function ArenaPage() {
     }, [setLoading]);
 
     return (
-        <div className="min-h-screen bg-background-400 text-font-100 py-12 space-y-10">
+        <div className="min-h-screen space-y-10 bg-background-400 py-12 text-font-100">
             <ArenaPageHeader />
             <Modals />
             {(() => {

--- a/app/(base)/arenas/[id]/components/ArenaDetailVote.tsx
+++ b/app/(base)/arenas/[id]/components/ArenaDetailVote.tsx
@@ -64,11 +64,11 @@ export default function ArenaDetailVote() {
     };
 
     return (
-        <div className="w-full max-w-[1000px] mt-6 bg-background-300 rounded-xl px-6 py-4 flex flex-col items-center justify-center gap-4 min-h-[200px] animate-fade-in-up">
+        <div className="mt-6 flex min-h-[200px] w-full max-w-[1000px] animate-fade-in-up flex-col items-center justify-center gap-4 rounded-xl bg-background-300 px-6 py-4">
             {/* 상단 투표 영역 */}
-            <div className="w-full flex flex-col lg:flex-row gap-4 lg:items-center justify-center relative">
+            <div className="relative flex w-full flex-col justify-center gap-4 lg:flex-row lg:items-center">
                 {/* 왼쪽 유저 */}
-                <div className="flex-1 flex flex-col-reverse lg:flex-row items-center gap-2 lg:gap-2 text-center lg:text-left justify-start">
+                <div className="flex flex-1 flex-col-reverse items-center justify-start gap-2 text-center lg:flex-row lg:gap-2 lg:text-left">
                     {arenaDetail?.status === 4 ? (
                         <Button
                             label={isVotedToLeft ? "✔" : "투표"}
@@ -77,11 +77,11 @@ export default function ArenaDetailVote() {
                             disabled={loading}
                         />
                     ) : (
-                        <div className="w-full lg:w-24 text-font-100 font-bold text-center">
-                            {Math.round(leftPercent)}%
+                        <div className="w-full text-center font-bold text-font-100 lg:w-24">
+                            {leftPercent}%
                         </div>
                     )}
-                    <div className="flex items-center gap-2 text-font-100 text-body">
+                    <div className="flex items-center gap-2 text-body text-font-100">
                         <Image
                             src="/icons/teamA.svg"
                             alt="게시자 아이콘"
@@ -100,10 +100,10 @@ export default function ArenaDetailVote() {
 
                 {/* 중앙 VS or 모바일 게이지 */}
                 <div className="flex w-auto justify-center">
-                    <div className="hidden lg:flex items-center justify-center w-10 h-10 rounded-full bg-background-200 text-white font-bold text-sm">
+                    <div className="hidden h-10 w-10 items-center justify-center rounded-full bg-background-200 text-sm font-bold text-white lg:flex">
                         VS
                     </div>
-                    <div className="lg:hidden w-full">
+                    <div className="w-full lg:hidden">
                         {arenaDetail?.status === 5 && (
                             <VoteStatusBar leftPercent={leftPercent} />
                         )}
@@ -111,8 +111,8 @@ export default function ArenaDetailVote() {
                 </div>
 
                 {/* 오른쪽 유저 */}
-                <div className="flex-1 flex flex-col lg:flex-row items-center gap-2 lg:gap-2 text-center lg:text-right justify-end">
-                    <div className="flex flex-row items-center gap-2 text-font-100 text-body lg:flex-row-reverse">
+                <div className="flex flex-1 flex-col items-center justify-end gap-2 text-center lg:flex-row lg:gap-2 lg:text-right">
+                    <div className="flex flex-row items-center gap-2 text-body text-font-100 lg:flex-row-reverse">
                         <Image
                             src="/icons/teamB.svg"
                             alt="게시자 아이콘"
@@ -136,8 +136,8 @@ export default function ArenaDetailVote() {
                             disabled={loading}
                         />
                     ) : (
-                        <div className="w-full lg:w-24 text-font-100 font-bold text-center">
-                            {Math.round(rightPercent)}%
+                        <div className="w-full text-center font-bold text-font-100 lg:w-24">
+                            {rightPercent}%
                         </div>
                     )}
                 </div>
@@ -145,13 +145,13 @@ export default function ArenaDetailVote() {
 
             {/* 데스크탑에선 투표 게이지 별도 위치에 */}
             {arenaDetail?.status === 5 && (
-                <div className="hidden lg:block w-full mt-4">
+                <div className="mt-4 hidden w-full lg:block">
                     <VoteStatusBar leftPercent={leftPercent} />
                 </div>
             )}
 
             {/* 하단 상태 메시지 */}
-            <div className="text-font-100 text-caption text-center">
+            <div className="text-center text-caption text-font-100">
                 {arenaDetail?.status === 4 ? (
                     <>
                         투표가 진행중입니다. 남은시간:{" "}
@@ -163,7 +163,7 @@ export default function ArenaDetailVote() {
             </div>
 
             {/* 에러 메시지 */}
-            {error && <div className="text-red-500 text-sm mt-2">{error}</div>}
+            {error && <div className="mt-2 text-sm text-red-500">{error}</div>}
         </div>
     );
 }

--- a/app/(base)/arenas/components/ArenaPageHeader.tsx
+++ b/app/(base)/arenas/components/ArenaPageHeader.tsx
@@ -5,7 +5,7 @@ import useModalStore from "@/stores/modalStore";
 
 export default function ArenaPageHeader() {
     return (
-        <div className="px-6 flex flex-col md:flex-row justify-between items-start md:items-center gap-4">
+        <div className="flex flex-col items-start justify-between gap-4 px-6 md:flex-row md:items-center">
             <div className="space-y-1">
                 <div className="flex items-center gap-2">
                     <Image

--- a/app/(base)/arenas/components/ArenaSectionHeader.tsx
+++ b/app/(base)/arenas/components/ArenaSectionHeader.tsx
@@ -15,7 +15,7 @@ export default function ArenaSectionHeader(props: ArenaSectionHeaderProps) {
     };
 
     return (
-        <div className="px-6 flex flex-col md:flex-row justify-between items-start md:items-center gap-4">
+        <div className="flex flex-col items-start justify-between gap-4 px-6 md:flex-row md:items-center">
             <div className="space-y-1">
                 <div className="flex items-center gap-2">
                     <Image
@@ -35,7 +35,7 @@ export default function ArenaSectionHeader(props: ArenaSectionHeaderProps) {
                 onClick={() => {
                     handleQueryChange(1, props.status);
                 }}
-                className="flex items-center gap-1 text-base text-purple-500 hover:underline whitespace-nowrap"
+                className="flex items-center gap-1 whitespace-nowrap text-base text-purple-500 hover:underline"
             >
                 <span>모두 보기</span>
                 <Image

--- a/app/(base)/arenas/components/CompleteArenaCard.tsx
+++ b/app/(base)/arenas/components/CompleteArenaCard.tsx
@@ -7,15 +7,21 @@ import { useRouter } from "next/navigation";
 
 type CompleteArenaCardProps = {
     id: number;
+    title: string;
+    description: string;
+
     creatorNickname: string;
     creatorProfileImageUrl: string;
     creatorScore: number;
     challengerNickname: string | null;
     challengerProfileImageUrl: string | null;
     challengerScore: number | null;
-    title: string;
-    description: string;
+
+    voteCount: number;
+    leftCount: number;
+    rightCount: number;
     leftPercent: number;
+    rightPercent: number;
 };
 
 export default function CompleteArenaCard(props: CompleteArenaCardProps) {
@@ -58,7 +64,7 @@ export default function CompleteArenaCard(props: CompleteArenaCardProps) {
 
                 {/* 도전자 */}
                 <div className="flex items-center gap-2">
-                    <span>{100 - props.leftPercent}%</span>
+                    <span>{props.rightPercent}%</span>
                     <Image
                         src={
                             props.challengerProfileImageUrl ||

--- a/app/(base)/arenas/components/CompleteArenaCard.tsx
+++ b/app/(base)/arenas/components/CompleteArenaCard.tsx
@@ -26,10 +26,7 @@ export default function CompleteArenaCard(props: CompleteArenaCardProps) {
 
     return (
         <div
-            className="bg-background-300 rounded-2xl gap-4 p-4 shadow-md text-white w-[670px]
-                border border-transparent hover:cursor-pointer hover:border-purple-500
-                hover:shadow-lg hover:shadow-purple-500/30
-                hover:scale-[1.01] transform transition-all duration-200"
+            className="w-[670px] transform gap-4 rounded-2xl border border-transparent bg-background-300 p-4 text-white shadow-md transition-all duration-200 hover:scale-[1.01] hover:cursor-pointer hover:border-purple-500 hover:shadow-lg hover:shadow-purple-500/30"
             onClick={onClickHandler}
         >
             <div className="rounded-2xl bg-background-200 p-4">
@@ -43,7 +40,7 @@ export default function CompleteArenaCard(props: CompleteArenaCardProps) {
             </div>
 
             <VoteStatusBar leftPercent={props.leftPercent} />
-            <div className="flex items-center justify-between gap-4 text-sm text-gray-100 mt-4 m-4">
+            <div className="m-4 mt-4 flex items-center justify-between gap-4 text-sm text-gray-100">
                 <div className="flex items-center gap-2">
                     <Image
                         src={props.creatorProfileImageUrl}

--- a/app/(base)/arenas/components/CompleteArenaSection.tsx
+++ b/app/(base)/arenas/components/CompleteArenaSection.tsx
@@ -96,8 +96,8 @@ export default function CompleteArenaSection({ onLoaded }: Props) {
 
     return (
         <div>
-            <ArenaSectionHeader status={5} />
-            <div className="grid grid-cols-1 sm:grid-cols-2 gap-6 mt-4 px-6">
+            <ArenaSectionHeader status={status} />
+            <div className="mt-4 grid grid-cols-1 gap-6 px-6 sm:grid-cols-2">
                 {arenaListDto?.arenas.length === 0 ? (
                     <div className="col-span-3 text-center text-gray-500">
                         {GetSectionTitle(status)}이 없습니다.

--- a/app/(base)/arenas/components/CompleteArenaSection.tsx
+++ b/app/(base)/arenas/components/CompleteArenaSection.tsx
@@ -3,8 +3,7 @@
 import useArenas from "@/hooks/useArenas";
 import ArenaSectionHeader from "./ArenaSectionHeader";
 import CompleteArenaCard from "./CompleteArenaCard";
-import useVoteList from "@/hooks/useVoteList";
-import { useEffect, useRef, useState } from "react";
+import { useEffect } from "react";
 import { useArenaAutoStatus } from "@/hooks/useArenaAutoStatus";
 import { GetSectionTitle } from "@/utils/GetSectionTitle";
 
@@ -15,11 +14,7 @@ interface Props {
 export default function CompleteArenaSection({ onLoaded }: Props) {
     const status: number = 5;
 
-    const {
-        arenaListDto,
-        loading: arenaLoading,
-        error: arenaError,
-    } = useArenas({
+    const { arenaListDto, loading, error } = useArenas({
         status,
         currentPage: 1,
         mine: false,
@@ -35,58 +30,25 @@ export default function CompleteArenaSection({ onLoaded }: Props) {
         },
     });
 
-    const [arenaIdsToFetch, setArenaIdsToFetch] = useState<number[]>([]);
-    const fetchedIdsRef = useRef<string>("");
-
-    useEffect(() => {
-        if (!arenaListDto?.arenas) return;
-
-        const ids = arenaListDto.arenas.map((arena) => arena.id).sort();
-        const idsString = ids.join(",");
-
-        if (fetchedIdsRef.current === idsString) return;
-
-        setArenaIdsToFetch(ids);
-        fetchedIdsRef.current = idsString;
-    }, [arenaListDto?.arenas]);
-
-    const {
-        voteResult,
-        loading: voteLoading,
-        error: voteError,
-    } = useVoteList({
-        arenaIds: arenaIdsToFetch,
-    });
-    // ✅ 완료된 투표 데이터를 arena 객체에 반영
-    if (arenaListDto && arenaListDto.arenas) {
-        arenaListDto.arenas.forEach((arena) => {
-            const vote = voteResult.find((vote) => vote.arenaId === arena.id);
-            if (vote) {
-                arena.voteCount = arena.voteCount;
-                arena.leftPercent = arena.leftPercent;
-            } else {
-                arena.voteCount = 0;
-            }
-        });
-    }
-
     // ✅ 로딩 완료되면 상위로 알림
     useEffect(() => {
-        if (!arenaLoading && !voteLoading) {
+        if (!loading) {
             onLoaded?.();
         }
-    }, [arenaLoading, voteLoading, onLoaded]);
+    }, [loading, onLoaded]);
 
-    if (arenaLoading || voteLoading) {
+    if (loading) {
         return (
+            // TODO: 로딩 컴포넌트 출력으로 변경하기
             <div className="col-span-3 text-center text-gray-400">
                 로딩중...
             </div>
         );
     }
 
-    if (arenaError || voteError) {
+    if (error) {
         return (
+            // TODO: 에러 컴포넌트 출력으로 변경하기
             <div className="col-span-3 text-center text-red-500">
                 투기장 정보를 불러오는 데 실패했습니다. 나중에 다시
                 시도해주세요.

--- a/app/(base)/arenas/components/CreateArenaModal.tsx
+++ b/app/(base)/arenas/components/CreateArenaModal.tsx
@@ -65,9 +65,9 @@ export default function CreateArenaModal() {
 
     return (
         <ModalWrapper isOpen={isOpen} onClose={closeModal}>
-            <div className="w-[480px] max-h-[80vh] flex flex-col gap-4 m-2">
+            <div className="m-2 flex max-h-[80vh] w-[480px] flex-col gap-4">
                 {/* ✅ 제목 */}
-                <h2 className="text-xl font-bold text-white flex items-center gap-2">
+                <h2 className="flex items-center gap-2 text-xl font-bold text-white">
                     <Image
                         src="/icons/arena2.svg"
                         alt="투기장 아이콘"
@@ -86,7 +86,7 @@ export default function CreateArenaModal() {
                         placeholder="토론 주제를 입력하세요"
                         value={title}
                         onChange={(e) => setTitle(e.target.value)}
-                        className="bg-zinc-800 text-white placeholder-zinc-400 px-4 py-2 rounded border border-purple-500 focus:outline-none focus:ring-2 focus:ring-purple-600"
+                        className="rounded border border-purple-500 bg-zinc-800 px-4 py-2 text-white placeholder-zinc-400 focus:outline-none focus:ring-2 focus:ring-purple-600"
                     />
                 </div>
 
@@ -97,12 +97,12 @@ export default function CreateArenaModal() {
                         placeholder="토론장 내용을 입력하세요"
                         value={description}
                         onChange={(e) => setDescription(e.target.value)}
-                        className="bg-zinc-800 text-white placeholder-zinc-400 px-4 py-2 rounded border border-zinc-600 resize-none h-28"
+                        className="h-28 resize-none rounded border border-zinc-600 bg-zinc-800 px-4 py-2 text-white placeholder-zinc-400"
                     />
                 </div>
 
                 {/* ✅ 일정  */}
-                <div className="text-black flex flex-col gap-2">
+                <div className="flex flex-col gap-2 text-black">
                     <label className="text-sm text-white">시작 시간</label>
                     <DatePicker
                         selected={startDate}
@@ -113,7 +113,7 @@ export default function CreateArenaModal() {
                         timeIntervals={10} // ⏱ 10분 단위
                         timeCaption="시간"
                         dateFormat="yyyy-MM-dd HH:mm"
-                        className="border border-gray-300 rounded px-3 py-2 w-full"
+                        className="w-full rounded border border-gray-300 px-3 py-2"
                     />
                 </div>
 

--- a/app/(base)/arenas/components/DebatingArenaCard.tsx
+++ b/app/(base)/arenas/components/DebatingArenaCard.tsx
@@ -22,22 +22,19 @@ export default function DebatingArenaCard(props: DebatingArenaCardProps) {
 
     return (
         <div
-            className="bg-background-300 rounded-2xl gap-4 p-4 shadow-md text-white w-[440px]
-                border border-transparent hover:cursor-pointer hover:border-purple-500
-                hover:shadow-lg hover:shadow-purple-500/30
-                hover:scale-[1.01] transform transition-all duration-200"
+            className="w-[440px] transform gap-4 rounded-2xl border border-transparent bg-background-300 p-4 text-white shadow-md transition-all duration-200 hover:scale-[1.01] hover:cursor-pointer hover:border-purple-500 hover:shadow-lg hover:shadow-purple-500/30"
             onClick={onClickHandler}
         >
             <div className="flex items-center justify-between">
-                <div className="text-lg font-bold line-clamp-2">
+                <div className="line-clamp-2 text-lg font-bold">
                     {props.title}
                 </div>
-                <div className="bg-purple-500 text-white text-xs font-semibold px-3 py-1 rounded-full">
+                <div className="rounded-full bg-purple-500 px-3 py-1 text-xs font-semibold text-white">
                     토론중
                 </div>
             </div>
 
-            <div className="flex items-center justify-between gap-4 text-sm text-gray-100 mt-4 m-4">
+            <div className="m-4 mt-4 flex items-center justify-between gap-4 text-sm text-gray-100">
                 <div className="flex items-center gap-2">
                     <span>{props.creatorNickname}</span>
                     <TierBadge score={props.creatorScore} size="sm" />
@@ -52,7 +49,7 @@ export default function DebatingArenaCard(props: DebatingArenaCardProps) {
                 </div>
             </div>
 
-            <div className="flex items-center justify-between text-sm text-gray-300 mt-4">
+            <div className="mt-4 flex items-center justify-between text-sm text-gray-300">
                 <div className="flex items-center gap-1">
                     <Image
                         src="/icons/infoCalendar.svg"

--- a/app/(base)/arenas/components/DebatingArenaSection.tsx
+++ b/app/(base)/arenas/components/DebatingArenaSection.tsx
@@ -57,7 +57,7 @@ export default function DebatingArenaSection({ onLoaded }: Props) {
     return (
         <div>
             <ArenaSectionHeader status={3} />
-            <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-6 mt-4 px-6">
+            <div className="mt-4 grid grid-cols-1 gap-6 px-6 sm:grid-cols-2 lg:grid-cols-3">
                 {arenaListDto?.arenas.length === 0 ? (
                     <div className="col-span-3 text-center text-gray-500">
                         현재 {GetSectionTitle(status)}이 없습니다.

--- a/app/(base)/arenas/components/RecruitingArenaCard.tsx
+++ b/app/(base)/arenas/components/RecruitingArenaCard.tsx
@@ -22,10 +22,7 @@ export default function RecruitingArenaCard(props: RecruitingArenaCardProps) {
 
     return (
         <div
-            className="bg-background-300 rounded-2xl gap-4 p-4 shadow-md text-white w-[670px]
-                border border-transparent hover:cursor-pointer hover:border-purple-500
-                hover:shadow-lg hover:shadow-purple-500/30
-                hover:scale-[1.01] transform transition-all duration-200"
+            className="w-[670px] transform gap-4 rounded-2xl border border-transparent bg-background-300 p-4 text-white shadow-md transition-all duration-200 hover:scale-[1.01] hover:cursor-pointer hover:border-purple-500 hover:shadow-lg hover:shadow-purple-500/30"
             onClick={onClickHandler}
         >
             <div className="flex items-center justify-between pb-2">
@@ -41,7 +38,7 @@ export default function RecruitingArenaCard(props: RecruitingArenaCardProps) {
                     <span>{props.creatorNickname}</span>
                     <TierBadge score={props.creatorScore} size="sm" />
                 </div>
-                <div className="bg-background-200 text-white text-xs font-semibold px-3 py-1 rounded-full">
+                <div className="rounded-full bg-background-200 px-3 py-1 text-xs font-semibold text-white">
                     모집중
                 </div>
             </div>
@@ -57,9 +54,9 @@ export default function RecruitingArenaCard(props: RecruitingArenaCardProps) {
             </div>
 
             {/* 하단 영역 */}
-            <div className="flex items-center justify-between mt-2">
+            <div className="mt-2 flex items-center justify-between">
                 {/* 시작 시간 */}
-                <div className="flex items-center gap-1 text-gray-400 text-sm">
+                <div className="flex items-center gap-1 text-sm text-gray-400">
                     <Image
                         src="/icons/infoCalendar.svg"
                         alt="달력 아이콘"

--- a/app/(base)/arenas/components/RecruitingArenaSection.tsx
+++ b/app/(base)/arenas/components/RecruitingArenaSection.tsx
@@ -18,7 +18,7 @@ export default function RecruitingArenaSection({ onLoaded }: Props) {
         status,
         currentPage: 1,
         mine: false,
-        pageSize: 3,
+        pageSize: 2,
     });
 
     useArenaAutoStatus({
@@ -57,7 +57,7 @@ export default function RecruitingArenaSection({ onLoaded }: Props) {
     return (
         <div>
             <ArenaSectionHeader status={status} />
-            <div className="grid grid-cols-1 sm:grid-cols-2 gap-6 mt-4 px-6">
+            <div className="mt-4 grid grid-cols-1 gap-6 px-6 sm:grid-cols-2">
                 {arenaListDto?.arenas.length === 0 ? (
                     <div className="col-span-3 text-center text-gray-500">
                         현재 {GetSectionTitle(status)}이 없습니다.

--- a/app/(base)/arenas/components/SelectedArenaSection.tsx
+++ b/app/(base)/arenas/components/SelectedArenaSection.tsx
@@ -108,7 +108,7 @@ export default function SelectedArenaSection({
             <div
                 className={`grid grid-cols-1 sm:grid-cols-2 ${
                     [1, 5].includes(status) ? "" : "lg:grid-cols-3"
-                } gap-6 mt-4 px-6`}
+                } mt-4 gap-6 px-6`}
             >
                 {arenaListDto?.arenas.length === 0 ? (
                     <div className="col-span-3 text-center text-gray-500">
@@ -168,7 +168,7 @@ export default function SelectedArenaSection({
             </div>
 
             {arenaListDto?.arenas.length !== 0 && (
-                <div className="w-full flex justify-center mt-12">
+                <div className="mt-12 flex w-full justify-center">
                     <Pager
                         currentPage={currentPage}
                         pages={pages}

--- a/app/(base)/arenas/components/VoteStatusBar.tsx
+++ b/app/(base)/arenas/components/VoteStatusBar.tsx
@@ -6,7 +6,7 @@ type VoteStatusBarProps = {
 
 export default function VoteStatusBar(props: VoteStatusBarProps) {
     return (
-        <div className="w-full mt-4 h-3 rounded-lg overflow-hidden flex">
+        <div className="mt-4 flex h-3 w-full overflow-hidden rounded-lg">
             <div
                 className="rounded-l-lg"
                 style={{

--- a/app/(base)/arenas/components/VotingArenaCard.tsx
+++ b/app/(base)/arenas/components/VotingArenaCard.tsx
@@ -23,22 +23,19 @@ export default function VotingArenaCard(props: VotingArenaCardProps) {
 
     return (
         <div
-            className="bg-background-300 rounded-2xl gap-4 p-4 shadow-md text-white w-[440px]
-                border border-transparent hover:cursor-pointer hover:border-purple-500
-                hover:shadow-lg hover:shadow-purple-500/30
-                hover:scale-[1.01] transform transition-all duration-200"
+            className="w-[440px] transform gap-4 rounded-2xl border border-transparent bg-background-300 p-4 text-white shadow-md transition-all duration-200 hover:scale-[1.01] hover:cursor-pointer hover:border-purple-500 hover:shadow-lg hover:shadow-purple-500/30"
             onClick={onClickHandler}
         >
             <div className="flex items-center justify-between">
-                <div className="text-lg font-bold line-clamp-2">
+                <div className="line-clamp-2 text-lg font-bold">
                     {props.title}
                 </div>
-                <div className="bg-purple-500 text-white text-xs font-semibold px-3 py-1 rounded-full">
+                <div className="rounded-full bg-purple-500 px-3 py-1 text-xs font-semibold text-white">
                     투표중
                 </div>
             </div>
 
-            <div className="flex items-center justify-between gap-4 text-sm text-gray-100 mt-2 m-2">
+            <div className="m-2 mt-2 flex items-center justify-between gap-4 text-sm text-gray-100">
                 <div className="flex items-center gap-2">
                     <span>{props.creatorNickname}</span>
                     <TierBadge score={props.creatorScore} size="sm" />
@@ -53,7 +50,7 @@ export default function VotingArenaCard(props: VotingArenaCardProps) {
                 </div>
             </div>
 
-            <div className="flex items-center justify-between text-sm text-gray-300 mt-4">
+            <div className="mt-4 flex items-center justify-between text-sm text-gray-300">
                 <div className="flex items-center gap-1">
                     <Image
                         src="/icons/infoCalendar.svg"

--- a/app/(base)/arenas/components/VotingArenaSection.tsx
+++ b/app/(base)/arenas/components/VotingArenaSection.tsx
@@ -96,7 +96,7 @@ export default function VotingArenaSection({ onLoaded }: Props) {
     return (
         <div>
             <ArenaSectionHeader status={4} />
-            <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-6 mt-4 px-6">
+            <div className="mt-4 grid grid-cols-1 gap-6 px-6 sm:grid-cols-2 lg:grid-cols-3">
                 {arenaListDto?.arenas.length === 0 ? (
                     <div className="col-span-3 text-center text-gray-500">
                         현재 {GetSectionTitle(status)}이 없습니다.

--- a/app/(base)/arenas/components/WaitingArenaCard.tsx
+++ b/app/(base)/arenas/components/WaitingArenaCard.tsx
@@ -22,22 +22,19 @@ export default function WaitingArenaCard(props: WaitingArenaCardProps) {
 
     return (
         <div
-            className="bg-background-300 rounded-2xl gap-4 p-4 shadow-md text-white w-[440px]
-                border border-transparent hover:cursor-pointer hover:border-purple-500
-                hover:shadow-lg hover:shadow-purple-500/30
-                hover:scale-[1.01] transform transition-all duration-200"
+            className="w-[440px] transform gap-4 rounded-2xl border border-transparent bg-background-300 p-4 text-white shadow-md transition-all duration-200 hover:scale-[1.01] hover:cursor-pointer hover:border-purple-500 hover:shadow-lg hover:shadow-purple-500/30"
             onClick={onClickHandler}
         >
             <div className="flex items-center justify-between">
-                <div className="text-lg font-bold line-clamp-2">
+                <div className="line-clamp-2 text-lg font-bold">
                     {props.title}
                 </div>
-                <div className="bg-background-200 text-white text-xs font-semibold px-3 py-1 rounded-full">
+                <div className="rounded-full bg-background-200 px-3 py-1 text-xs font-semibold text-white">
                     대기중
                 </div>
             </div>
 
-            <div className="flex items-center justify-between gap-4 text-sm text-gray-100 mt-4 m-4">
+            <div className="m-4 mt-4 flex items-center justify-between gap-4 text-sm text-gray-100">
                 <div className="flex items-center gap-2">
                     <span>{props.creatorNickname}</span>
                     <TierBadge score={props.creatorScore} size="sm" />
@@ -52,7 +49,7 @@ export default function WaitingArenaCard(props: WaitingArenaCardProps) {
                 </div>
             </div>
 
-            <div className="flex items-center justify-between text-sm text-gray-300 mt-4">
+            <div className="mt-4 flex items-center justify-between text-sm text-gray-300">
                 <div className="flex items-center gap-1">
                     <Image
                         src="/icons/infoCalendar.svg"

--- a/app/(base)/arenas/components/WaitingArenaSection.tsx
+++ b/app/(base)/arenas/components/WaitingArenaSection.tsx
@@ -57,7 +57,7 @@ export default function WaitingArenaSection({ onLoaded }: Props) {
     return (
         <div>
             <ArenaSectionHeader status={2} />
-            <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-6 mt-4 px-6">
+            <div className="mt-4 grid grid-cols-1 gap-6 px-6 sm:grid-cols-2 lg:grid-cols-3">
                 {arenaListDto?.arenas.length === 0 ? (
                     <div className="col-span-3 text-center text-gray-500">
                         현재 {GetSectionTitle(status)}이 없습니다.

--- a/backend/arena/application/usecase/GetArenaDetailUsecase.ts
+++ b/backend/arena/application/usecase/GetArenaDetailUsecase.ts
@@ -45,20 +45,24 @@ export class GetArenaDetailUsecase {
         const endVote = new Date(endChatting.getTime() + 24 * 60 * 60 * 1000);
 
         const totalFilter: VoteFilter = new VoteFilter(arenaId, null, null);
-        const voteTotalCount: number = await this.voteRepository.count(
-            totalFilter
-        );
+        const voteTotalCount: number =
+            await this.voteRepository.count(totalFilter);
         const leftFilter: VoteFilter = new VoteFilter(
             arenaId,
             null,
             ArenaDetail.creatorId
         );
-        const voteLeftCount: number = await this.voteRepository.count(
-            leftFilter
-        );
+        const voteLeftCount: number =
+            await this.voteRepository.count(leftFilter);
         const voteRightCount: number = voteTotalCount - voteLeftCount;
-        const leftPercent: number = (voteLeftCount / voteTotalCount) * 100;
-        const rightPercent: number = (voteRightCount / voteTotalCount) * 100;
+        const leftPercent: number =
+            voteTotalCount === 0
+                ? 0
+                : Math.round((voteLeftCount / voteTotalCount) * 100);
+        const rightPercent: number =
+            voteTotalCount === 0
+                ? 0
+                : Math.round((voteRightCount / voteTotalCount) * 100);
         console.log("--- ArenaDetailDto 생성 직전 값 확인 ---");
         console.log("voteTotalCount:", voteTotalCount);
         console.log("voteLeftCount:", voteLeftCount);

--- a/backend/arena/application/usecase/GetArenaUsecase.ts
+++ b/backend/arena/application/usecase/GetArenaUsecase.ts
@@ -76,9 +76,17 @@ export class GetArenaUsecase {
                     const voteRightCount: number =
                         voteTotalCount - voteLeftCount;
                     const leftPercent: number =
-                        (voteLeftCount / voteTotalCount) * 100;
+                        voteTotalCount === 0
+                            ? 0
+                            : Math.round(
+                                  (voteLeftCount / voteTotalCount) * 100
+                              );
                     const rightPercent: number =
-                        (voteRightCount / voteTotalCount) * 100;
+                        voteTotalCount === 0
+                            ? 0
+                            : Math.round(
+                                  (voteRightCount / voteTotalCount) * 100
+                              );
                     return {
                         id: arena.id,
                         creatorId: arena.creatorId,

--- a/package-lock.json
+++ b/package-lock.json
@@ -26,7 +26,7 @@
                 "lottie-react": "^2.4.1",
                 "lucide": "^0.525.0",
                 "lucide-react": "^0.511.0",
-                "next": "15.3.2",
+                "next": "^15.4.2",
                 "next-auth": "^4.24.11",
                 "react": "^19.0.0",
                 "react-datepicker": "^8.4.0",
@@ -834,9 +834,10 @@
             }
         },
         "node_modules/@next/env": {
-            "version": "15.3.2",
-            "resolved": "https://registry.npmjs.org/@next/env/-/env-15.3.2.tgz",
-            "integrity": "sha512-xURk++7P7qR9JG1jJtLzPzf0qEvqCN0A/T3DXf8IPMKo9/6FfjxtEffRJIIew/bIL4T3C2jLLqBor8B/zVlx6g=="
+            "version": "15.4.2",
+            "resolved": "https://registry.npmjs.org/@next/env/-/env-15.4.2.tgz",
+            "integrity": "sha512-kd7MvW3pAP7tmk1NaiX4yG15xb2l4gNhteKQxt3f+NGR22qwPymn9RBuv26QKfIKmfo6z2NpgU8W2RT0s0jlvg==",
+            "license": "MIT"
         },
         "node_modules/@next/eslint-plugin-next": {
             "version": "15.3.2",
@@ -848,12 +849,13 @@
             }
         },
         "node_modules/@next/swc-darwin-arm64": {
-            "version": "15.3.2",
-            "resolved": "https://registry.npmjs.org/@next/swc-darwin-arm64/-/swc-darwin-arm64-15.3.2.tgz",
-            "integrity": "sha512-2DR6kY/OGcokbnCsjHpNeQblqCZ85/1j6njYSkzRdpLn5At7OkSdmk7WyAmB9G0k25+VgqVZ/u356OSoQZ3z0g==",
+            "version": "15.4.2",
+            "resolved": "https://registry.npmjs.org/@next/swc-darwin-arm64/-/swc-darwin-arm64-15.4.2.tgz",
+            "integrity": "sha512-ovqjR8NjCBdBf1U+R/Gvn0RazTtXS9n6wqs84iFaCS1NHbw9ksVE4dfmsYcLoyUVd9BWE0bjkphOWrrz8uz/uw==",
             "cpu": [
                 "arm64"
             ],
+            "license": "MIT",
             "optional": true,
             "os": [
                 "darwin"
@@ -863,12 +865,13 @@
             }
         },
         "node_modules/@next/swc-darwin-x64": {
-            "version": "15.3.2",
-            "resolved": "https://registry.npmjs.org/@next/swc-darwin-x64/-/swc-darwin-x64-15.3.2.tgz",
-            "integrity": "sha512-ro/fdqaZWL6k1S/5CLv1I0DaZfDVJkWNaUU3un8Lg6m0YENWlDulmIWzV96Iou2wEYyEsZq51mwV8+XQXqMp3w==",
+            "version": "15.4.2",
+            "resolved": "https://registry.npmjs.org/@next/swc-darwin-x64/-/swc-darwin-x64-15.4.2.tgz",
+            "integrity": "sha512-I8d4W7tPqbdbHRI4z1iBfaoJIBrEG4fnWKIe+Rj1vIucNZ5cEinfwkBt3RcDF00bFRZRDpvKuDjgMFD3OyRBnw==",
             "cpu": [
                 "x64"
             ],
+            "license": "MIT",
             "optional": true,
             "os": [
                 "darwin"
@@ -878,12 +881,13 @@
             }
         },
         "node_modules/@next/swc-linux-arm64-gnu": {
-            "version": "15.3.2",
-            "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-gnu/-/swc-linux-arm64-gnu-15.3.2.tgz",
-            "integrity": "sha512-covwwtZYhlbRWK2HlYX9835qXum4xYZ3E2Mra1mdQ+0ICGoMiw1+nVAn4d9Bo7R3JqSmK1grMq/va+0cdh7bJA==",
+            "version": "15.4.2",
+            "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-gnu/-/swc-linux-arm64-gnu-15.4.2.tgz",
+            "integrity": "sha512-lvhz02dU3Ec5thzfQ2RCUeOFADjNkS/px1W7MBt7HMhf0/amMfT8Z/aXOwEA+cVWN7HSDRSUc8hHILoHmvajsg==",
             "cpu": [
                 "arm64"
             ],
+            "license": "MIT",
             "optional": true,
             "os": [
                 "linux"
@@ -893,12 +897,13 @@
             }
         },
         "node_modules/@next/swc-linux-arm64-musl": {
-            "version": "15.3.2",
-            "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-musl/-/swc-linux-arm64-musl-15.3.2.tgz",
-            "integrity": "sha512-KQkMEillvlW5Qk5mtGA/3Yz0/tzpNlSw6/3/ttsV1lNtMuOHcGii3zVeXZyi4EJmmLDKYcTcByV2wVsOhDt/zg==",
+            "version": "15.4.2",
+            "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-musl/-/swc-linux-arm64-musl-15.4.2.tgz",
+            "integrity": "sha512-v+5PPfL8UP+KKHS3Mox7QMoeFdMlaV0zeNMIF7eLC4qTiVSO0RPNnK0nkBZSD5BEkkf//c+vI9s/iHxddCZchA==",
             "cpu": [
                 "arm64"
             ],
+            "license": "MIT",
             "optional": true,
             "os": [
                 "linux"
@@ -908,12 +913,13 @@
             }
         },
         "node_modules/@next/swc-linux-x64-gnu": {
-            "version": "15.3.2",
-            "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-gnu/-/swc-linux-x64-gnu-15.3.2.tgz",
-            "integrity": "sha512-uRBo6THWei0chz+Y5j37qzx+BtoDRFIkDzZjlpCItBRXyMPIg079eIkOCl3aqr2tkxL4HFyJ4GHDes7W8HuAUg==",
+            "version": "15.4.2",
+            "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-gnu/-/swc-linux-x64-gnu-15.4.2.tgz",
+            "integrity": "sha512-PHLYOC9W2cu6I/JEKo77+LW4uPNvyEQiSkVRUQPsOIsf01PRr8PtPhwtz3XNnC9At8CrzPkzqQ9/kYDg4R4Inw==",
             "cpu": [
                 "x64"
             ],
+            "license": "MIT",
             "optional": true,
             "os": [
                 "linux"
@@ -923,12 +929,13 @@
             }
         },
         "node_modules/@next/swc-linux-x64-musl": {
-            "version": "15.3.2",
-            "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-musl/-/swc-linux-x64-musl-15.3.2.tgz",
-            "integrity": "sha512-+uxFlPuCNx/T9PdMClOqeE8USKzj8tVz37KflT3Kdbx/LOlZBRI2yxuIcmx1mPNK8DwSOMNCr4ureSet7eyC0w==",
+            "version": "15.4.2",
+            "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-musl/-/swc-linux-x64-musl-15.4.2.tgz",
+            "integrity": "sha512-lpmUF9FfLFns4JbTu+5aJGA8aR9dXaA12eoNe9CJbVkGib0FDiPa4kBGTwy0xDxKNGlv3bLDViyx1U+qafmuJQ==",
             "cpu": [
                 "x64"
             ],
+            "license": "MIT",
             "optional": true,
             "os": [
                 "linux"
@@ -938,12 +945,13 @@
             }
         },
         "node_modules/@next/swc-win32-arm64-msvc": {
-            "version": "15.3.2",
-            "resolved": "https://registry.npmjs.org/@next/swc-win32-arm64-msvc/-/swc-win32-arm64-msvc-15.3.2.tgz",
-            "integrity": "sha512-LLTKmaI5cfD8dVzh5Vt7+OMo+AIOClEdIU/TSKbXXT2iScUTSxOGoBhfuv+FU8R9MLmrkIL1e2fBMkEEjYAtPQ==",
+            "version": "15.4.2",
+            "resolved": "https://registry.npmjs.org/@next/swc-win32-arm64-msvc/-/swc-win32-arm64-msvc-15.4.2.tgz",
+            "integrity": "sha512-aMjogoGnRepas0LQ/PBPsvvUzj+IoXw2IoDSEShEtrsu2toBiaxEWzOQuPZ8nie8+1iF7TA63S7rlp3YWAjNEg==",
             "cpu": [
                 "arm64"
             ],
+            "license": "MIT",
             "optional": true,
             "os": [
                 "win32"
@@ -953,12 +961,13 @@
             }
         },
         "node_modules/@next/swc-win32-x64-msvc": {
-            "version": "15.3.2",
-            "resolved": "https://registry.npmjs.org/@next/swc-win32-x64-msvc/-/swc-win32-x64-msvc-15.3.2.tgz",
-            "integrity": "sha512-aW5B8wOPioJ4mBdMDXkt5f3j8pUr9W8AnlX0Df35uRWNT1Y6RIybxjnSUe+PhM+M1bwgyY8PHLmXZC6zT1o5tA==",
+            "version": "15.4.2",
+            "resolved": "https://registry.npmjs.org/@next/swc-win32-x64-msvc/-/swc-win32-x64-msvc-15.4.2.tgz",
+            "integrity": "sha512-FxwauyexSFu78wEqR/+NB9MnqXVj6SxJKwcVs2CRjeSX/jBagDCgtR2W36PZUYm0WPgY1pQ3C1+nn7zSnwROuw==",
             "cpu": [
                 "x64"
             ],
+            "license": "MIT",
             "optional": true,
             "os": [
                 "win32"
@@ -1130,11 +1139,6 @@
             "version": "3.1.2",
             "resolved": "https://registry.npmjs.org/@socket.io/component-emitter/-/component-emitter-3.1.2.tgz",
             "integrity": "sha512-9BCxFwvbGg/RsZK9tjXd8s4UcwR0MWeFQ1XEKIQVVvAGJyINdrqKMcTRyLoK8Rse1GjzLV9cwjWV1olXRWEXVA=="
-        },
-        "node_modules/@swc/counter": {
-            "version": "0.1.3",
-            "resolved": "https://registry.npmjs.org/@swc/counter/-/counter-0.1.3.tgz",
-            "integrity": "sha512-e2BR4lsJkkRlKZ/qCHPw9ZaSxc0MVUd7gtbtaB7aMvHeJVYe8sOB8DBZkP2DtISHGSku9sCK6T6cnY0CtXrOCQ=="
         },
         "node_modules/@swc/helpers": {
             "version": "0.5.15",
@@ -2855,17 +2859,6 @@
             },
             "engines": {
                 "node": "^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7"
-            }
-        },
-        "node_modules/busboy": {
-            "version": "1.6.0",
-            "resolved": "https://registry.npmjs.org/busboy/-/busboy-1.6.0.tgz",
-            "integrity": "sha512-8SFQbg/0hQ9xy3UNTB0YEnsNBbWfhf7RtnzpL7TkBiTBRfrQ9Fxcnz7VJsleJpyp6rVLvXiuORqjlHi5q+PYuA==",
-            "dependencies": {
-                "streamsearch": "^1.1.0"
-            },
-            "engines": {
-                "node": ">=10.16.0"
             }
         },
         "node_modules/call-bind": {
@@ -5738,14 +5731,13 @@
             }
         },
         "node_modules/next": {
-            "version": "15.3.2",
-            "resolved": "https://registry.npmjs.org/next/-/next-15.3.2.tgz",
-            "integrity": "sha512-CA3BatMyHkxZ48sgOCLdVHjFU36N7TF1HhqAHLFOkV6buwZnvMI84Cug8xD56B9mCuKrqXnLn94417GrZ/jjCQ==",
+            "version": "15.4.2",
+            "resolved": "https://registry.npmjs.org/next/-/next-15.4.2.tgz",
+            "integrity": "sha512-oH1rmFso+84NIkocfuxaGKcXIjMUTmnzV2x0m8qsYtB4gD6iflLMESXt5XJ8cFgWMBei4v88rNr/j+peNg72XA==",
+            "license": "MIT",
             "dependencies": {
-                "@next/env": "15.3.2",
-                "@swc/counter": "0.1.3",
+                "@next/env": "15.4.2",
                 "@swc/helpers": "0.5.15",
-                "busboy": "1.6.0",
                 "caniuse-lite": "^1.0.30001579",
                 "postcss": "8.4.31",
                 "styled-jsx": "5.1.6"
@@ -5757,19 +5749,19 @@
                 "node": "^18.18.0 || ^19.8.0 || >= 20.0.0"
             },
             "optionalDependencies": {
-                "@next/swc-darwin-arm64": "15.3.2",
-                "@next/swc-darwin-x64": "15.3.2",
-                "@next/swc-linux-arm64-gnu": "15.3.2",
-                "@next/swc-linux-arm64-musl": "15.3.2",
-                "@next/swc-linux-x64-gnu": "15.3.2",
-                "@next/swc-linux-x64-musl": "15.3.2",
-                "@next/swc-win32-arm64-msvc": "15.3.2",
-                "@next/swc-win32-x64-msvc": "15.3.2",
-                "sharp": "^0.34.1"
+                "@next/swc-darwin-arm64": "15.4.2",
+                "@next/swc-darwin-x64": "15.4.2",
+                "@next/swc-linux-arm64-gnu": "15.4.2",
+                "@next/swc-linux-arm64-musl": "15.4.2",
+                "@next/swc-linux-x64-gnu": "15.4.2",
+                "@next/swc-linux-x64-musl": "15.4.2",
+                "@next/swc-win32-arm64-msvc": "15.4.2",
+                "@next/swc-win32-x64-msvc": "15.4.2",
+                "sharp": "^0.34.3"
             },
             "peerDependencies": {
                 "@opentelemetry/api": "^1.1.0",
-                "@playwright/test": "^1.41.2",
+                "@playwright/test": "^1.51.1",
                 "babel-plugin-react-compiler": "*",
                 "react": "^18.2.0 || 19.0.0-rc-de68d2f4-20241204 || ^19.0.0",
                 "react-dom": "^18.2.0 || 19.0.0-rc-de68d2f4-20241204 || ^19.0.0",
@@ -7293,14 +7285,6 @@
             },
             "engines": {
                 "node": ">= 0.4"
-            }
-        },
-        "node_modules/streamsearch": {
-            "version": "1.1.0",
-            "resolved": "https://registry.npmjs.org/streamsearch/-/streamsearch-1.1.0.tgz",
-            "integrity": "sha512-Mcc5wHehp9aXz1ax6bZUyY5afg9u2rv5cqQI3mRrYkGC8rW2hM02jWuwjtL++LS5qinSyhj2QfLyNsuc+VsExg==",
-            "engines": {
-                "node": ">=10.0.0"
             }
         },
         "node_modules/string-width": {

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
         "lottie-react": "^2.4.1",
         "lucide": "^0.525.0",
         "lucide-react": "^0.511.0",
-        "next": "15.3.2",
+        "next": "^15.4.2",
         "next-auth": "^4.24.11",
         "react": "^19.0.0",
         "react-datepicker": "^8.4.0",


### PR DESCRIPTION
## ✨ 작업 개요
리팩토링된 백엔드 구조에 맞게 투기장 탐색 페이지에 적용하였습니다.

## ✅ 상세 내용
- [x] 투기장 탐색 페이지 및 컴포넌트에 prettier-plugin-tailwindcss 적용
- [x] 도전자를 찾는중인 투기장이 탐색 페이지에서 3개 보이던 현상 수정
- [x] 투표 완료된 투기장의 투표 정보 변경된 API 스펙에 맞게 올바르게 받아오도록 수정
- [x] 투표 count가 0인 경우 left, right percent가 NaN으로 계산되던 현상 수정
- [x] 백엔드에서 left, right percent 반올림하도록 수정 및 페이지에 적용 

## 📸 스크린샷 (선택)

## 🧪 확인 사항

-   [x] 정상적으로 동작하는지 직접 테스트해봤나요?
-   [x] 기능 추가/수정 후 UI나 비즈니스 로직에 영향은 없나요?
-   [ ] 투기장 탐색 페이지 내에 버그가 있는지 확인 부탁드려요

## 🙏 기타 참고 사항
Next.js 보안 이슈가 해결된 버전으로 업그레이드 진행했습니다.

## 이슈 관리

close #195 
