### PR TITLE
[style/#196] 투기장 탐색 페이지 반응형 디자인 적용

### DIFF
--- a/app/(base)/arenas/ArenaPage.tsx
+++ b/app/(base)/arenas/ArenaPage.tsx
@@ -45,7 +45,7 @@ export default function ArenaPage() {
     }, [setLoading]);
 
     return (
-        <div className="min-h-screen space-y-10 bg-background-400 py-12 text-font-100">
+        <div className="min-h-screen space-y-10 bg-background-400 py-6 text-font-100 sm:py-12">
             <ArenaPageHeader />
             <Modals />
             {(() => {

--- a/app/(base)/arenas/components/ArenaPageHeader.tsx
+++ b/app/(base)/arenas/components/ArenaPageHeader.tsx
@@ -19,7 +19,7 @@ export default function ArenaPageHeader() {
                         토론 투기장
                     </h1>
                 </div>
-                <p className="text-font-300 text-sm text-gray-400">
+                <p className="text-font-300 sm:text-md break-keep text-sm text-gray-400">
                     게임에 대한 열띤 토론의 장입니다. 자신의 의견을 피력하고
                     다른 게이머들과 논쟁을 벌여보세요. 토론에서 승리하여 최고의
                     평론가로 인정받으세요.

--- a/app/(base)/arenas/components/ArenaSectionHeader.tsx
+++ b/app/(base)/arenas/components/ArenaSectionHeader.tsx
@@ -25,7 +25,7 @@ export default function ArenaSectionHeader(props: ArenaSectionHeaderProps) {
                         height={20}
                         className="object-contain"
                     />
-                    <h1 className="text-xl font-semibold text-font-100">
+                    <h1 className="whitespace-nowrap text-lg font-semibold text-font-100 sm:text-xl">
                         {title}
                     </h1>
                 </div>

--- a/app/(base)/arenas/components/ArenaSectionHeader.tsx
+++ b/app/(base)/arenas/components/ArenaSectionHeader.tsx
@@ -15,7 +15,7 @@ export default function ArenaSectionHeader(props: ArenaSectionHeaderProps) {
     };
 
     return (
-        <div className="flex flex-col items-start justify-between gap-4 px-6 md:flex-row md:items-center">
+        <div className="flex flex-row items-start justify-between gap-4 px-6">
             <div className="space-y-1">
                 <div className="flex items-center gap-2">
                     <Image

--- a/app/(base)/arenas/components/CompleteArenaCard.tsx
+++ b/app/(base)/arenas/components/CompleteArenaCard.tsx
@@ -31,17 +31,19 @@ export default function CompleteArenaCard(props: CompleteArenaCardProps) {
     };
     return (
         <div
-            className="w-[670px] transform gap-4 rounded-2xl border border-transparent bg-background-300 p-4 text-white shadow-md transition-all duration-200 hover:scale-[1.01] hover:cursor-pointer hover:border-purple-500 hover:shadow-lg hover:shadow-purple-500/30"
+            className="flex h-full w-full transform flex-col gap-4 rounded-2xl border border-transparent bg-background-300 p-4 text-white shadow-md transition-all duration-200 hover:scale-[1.01] hover:cursor-pointer hover:border-purple-500 hover:shadow-lg hover:shadow-purple-500/30"
             onClick={onClickHandler}
         >
-            <div className="rounded-2xl bg-background-200 p-4">
+            <div className="flex-grow rounded-2xl bg-background-200 p-4">
                 {/* 제목 */}
                 <div className="text-base font-semibold text-white">
                     {props.title}
                 </div>
 
                 {/* 설명 */}
-                <div className="text-sm text-gray-300">{props.description}</div>
+                <div className="line-clamp-3 overflow-hidden text-sm text-gray-300">
+                    {props.description}
+                </div>
             </div>
 
             <VoteStatusBar
@@ -49,8 +51,9 @@ export default function CompleteArenaCard(props: CompleteArenaCardProps) {
                 leftPercent={props.leftPercent}
                 rightPercent={props.rightPercent}
             />
-            <div className="m-4 mt-4 flex items-center justify-between gap-4 text-sm text-gray-100">
-                <div className="flex items-center gap-2">
+            <div className="flex flex-col items-center gap-1 sm:flex-row sm:items-center sm:justify-between">
+                {/* 작성자 */}
+                <div className="flex min-w-0 flex-shrink items-center gap-2 overflow-hidden">
                     <Image
                         src={props.creatorProfileImageUrl}
                         alt="작성자 프로필"
@@ -58,16 +61,24 @@ export default function CompleteArenaCard(props: CompleteArenaCardProps) {
                         height={24}
                         className="rounded-full object-cover"
                     />
-                    <span>{props.creatorNickname}</span>
+                    <span className="max-w-[80px] truncate whitespace-nowrap">
+                        {props.creatorNickname}
+                    </span>
                     <TierBadge score={props.creatorScore} size="sm" />
-                    <span>{props.leftPercent}%</span>
+                    <span className="whitespace-nowrap">
+                        {props.leftPercent}%
+                    </span>
                 </div>
 
-                <span className="mx-2 text-gray-400">vs</span>
+                <span className="mx-2 flex-shrink-0 items-center text-gray-400">
+                    vs
+                </span>
 
                 {/* 도전자 */}
-                <div className="flex items-center gap-2">
-                    <span>{props.rightPercent}%</span>
+                <div className="flex min-w-0 flex-shrink items-center justify-end gap-2 overflow-hidden">
+                    <span className="whitespace-nowrap">
+                        {props.rightPercent}%
+                    </span>
                     <Image
                         src={
                             props.challengerProfileImageUrl ||
@@ -78,7 +89,9 @@ export default function CompleteArenaCard(props: CompleteArenaCardProps) {
                         height={24}
                         className="rounded-full object-cover"
                     />
-                    <span>{props.challengerNickname}</span>
+                    <span className="max-w-[80px] truncate whitespace-nowrap">
+                        {props.challengerNickname}
+                    </span>
                     <TierBadge score={props.challengerScore || 0} size="sm" />
                 </div>
             </div>

--- a/app/(base)/arenas/components/CompleteArenaCard.tsx
+++ b/app/(base)/arenas/components/CompleteArenaCard.tsx
@@ -36,12 +36,12 @@ export default function CompleteArenaCard(props: CompleteArenaCardProps) {
         >
             <div className="flex-grow rounded-2xl bg-background-200 p-4">
                 {/* 제목 */}
-                <div className="text-base font-semibold text-white">
+                <div className="break-keep text-base font-semibold text-white">
                     {props.title}
                 </div>
 
                 {/* 설명 */}
-                <div className="line-clamp-3 overflow-hidden text-sm text-gray-300">
+                <div className="line-clamp-3 overflow-hidden break-keep text-sm text-gray-300">
                     {props.description}
                 </div>
             </div>

--- a/app/(base)/arenas/components/CompleteArenaSection.tsx
+++ b/app/(base)/arenas/components/CompleteArenaSection.tsx
@@ -56,9 +56,10 @@ export default function CompleteArenaSection({ onLoaded }: Props) {
     return (
         <div>
             <ArenaSectionHeader status={status} />
-            <div className="mt-4 grid grid-cols-1 gap-6 px-6 sm:grid-cols-2">
+            <div className="mt-4 grid grid-cols-1 justify-center gap-6 px-4 sm:sm:[grid-template-columns:repeat(auto-fit,minmax(360px,1fr))]">
+                {" "}
                 {arenaListDto?.arenas.length === 0 ? (
-                    <div className="col-span-3 text-center text-gray-500">
+                    <div className="w-full text-center text-gray-500">
                         {GetSectionTitle(status)}이 없습니다.
                     </div>
                 ) : (

--- a/app/(base)/arenas/components/CompleteArenaSection.tsx
+++ b/app/(base)/arenas/components/CompleteArenaSection.tsx
@@ -56,7 +56,7 @@ export default function CompleteArenaSection({ onLoaded }: Props) {
     return (
         <div>
             <ArenaSectionHeader status={status} />
-            <div className="mt-4 grid grid-cols-1 justify-center gap-6 px-4 sm:sm:[grid-template-columns:repeat(auto-fit,minmax(360px,1fr))]">
+            <div className="mt-4 grid grid-cols-1 justify-center gap-6 px-4 sm:sm:[grid-template-columns:repeat(auto-fill,minmax(500px,1fr))]">
                 {" "}
                 {arenaListDto?.arenas.length === 0 ? (
                     <div className="w-full text-center text-gray-500">

--- a/app/(base)/arenas/components/CompleteArenaSection.tsx
+++ b/app/(base)/arenas/components/CompleteArenaSection.tsx
@@ -59,7 +59,7 @@ export default function CompleteArenaSection({ onLoaded }: Props) {
             <div className="mt-4 grid grid-cols-1 justify-center gap-6 px-4 sm:sm:[grid-template-columns:repeat(auto-fill,minmax(500px,1fr))]">
                 {" "}
                 {arenaListDto?.arenas.length === 0 ? (
-                    <div className="w-full text-center text-gray-500">
+                    <div className="w-full text-left text-gray-500">
                         {GetSectionTitle(status)}이 없습니다.
                     </div>
                 ) : (

--- a/app/(base)/arenas/components/CreateArenaModal.tsx
+++ b/app/(base)/arenas/components/CreateArenaModal.tsx
@@ -65,7 +65,7 @@ export default function CreateArenaModal() {
 
     return (
         <ModalWrapper isOpen={isOpen} onClose={closeModal}>
-            <div className="m-2 flex max-h-[80vh] w-[480px] flex-col gap-4">
+            <div className="flex flex-col gap-4">
                 {/* ✅ 제목 */}
                 <h2 className="flex items-center gap-2 text-xl font-bold text-white">
                     <Image

--- a/app/(base)/arenas/components/DebatingArenaCard.tsx
+++ b/app/(base)/arenas/components/DebatingArenaCard.tsx
@@ -22,35 +22,40 @@ export default function DebatingArenaCard(props: DebatingArenaCardProps) {
 
     return (
         <div
-            className="w-[440px] transform gap-4 rounded-2xl border border-transparent bg-background-300 p-4 text-white shadow-md transition-all duration-200 hover:scale-[1.01] hover:cursor-pointer hover:border-purple-500 hover:shadow-lg hover:shadow-purple-500/30"
+            className="flex h-full w-full transform flex-col gap-4 rounded-2xl border border-transparent bg-background-300 p-4 text-white shadow-md transition-all duration-200 hover:scale-[1.01] hover:cursor-pointer hover:border-purple-500 hover:shadow-lg hover:shadow-purple-500/30"
             onClick={onClickHandler}
         >
-            <div className="flex items-center justify-between">
-                <div className="line-clamp-2 text-lg font-bold">
+            <div className="flex flex-row items-start justify-between gap-1">
+                <div className="line-clamp-2 min-h-[3.5rem] break-keep text-lg font-bold">
                     {props.title}
                 </div>
-                <div className="rounded-full bg-purple-500 px-3 py-1 text-xs font-semibold text-white">
+                <div className="flex h-6 flex-shrink-0 items-center rounded-full bg-purple-500 px-3 text-xs font-semibold">
                     토론중
                 </div>
             </div>
 
-            <div className="m-4 mt-4 flex items-center justify-between gap-4 text-sm text-gray-100">
-                <div className="flex items-center gap-2">
-                    <span>{props.creatorNickname}</span>
+            <div className="flex items-center justify-between text-sm text-gray-100">
+                {/* 작성자 */}
+                <div className="flex min-w-0 flex-shrink items-center gap-2 overflow-hidden">
+                    <span className="max-w-[100px] truncate whitespace-nowrap">
+                        {props.creatorNickname}
+                    </span>
                     <TierBadge score={props.creatorScore} size="sm" />
                 </div>
 
                 <span className="mx-2 text-gray-400">vs</span>
 
                 {/* 도전자 */}
-                <div className="flex items-center gap-2">
-                    <span>{props.challengerNickname}</span>
+                <div className="flex min-w-0 flex-shrink items-center gap-2 overflow-hidden">
+                    <span className="max-w-[100px] truncate whitespace-nowrap">
+                        {props.challengerNickname}
+                    </span>
                     <TierBadge score={props.challengerScore || 0} size="sm" />
                 </div>
             </div>
 
-            <div className="mt-4 flex items-center justify-between text-sm text-gray-300">
-                <div className="flex items-center gap-1">
+            <div className="mt-2 flex items-center justify-between">
+                <div className="flex items-center gap-1 text-sm text-gray-400">
                     <Image
                         src="/icons/infoCalendar.svg"
                         alt="달력 아이콘"

--- a/app/(base)/arenas/components/DebatingArenaSection.tsx
+++ b/app/(base)/arenas/components/DebatingArenaSection.tsx
@@ -59,7 +59,7 @@ export default function DebatingArenaSection({ onLoaded }: Props) {
             <ArenaSectionHeader status={3} />
             <div className="mt-4 grid grid-cols-1 justify-center gap-6 px-4 sm:sm:[grid-template-columns:repeat(auto-fill,minmax(360px,1fr))]">
                 {arenaListDto?.arenas.length === 0 ? (
-                    <div className="w-full text-center text-gray-500">
+                    <div className="w-full text-left text-gray-500">
                         현재 {GetSectionTitle(status)}이 없습니다.
                     </div>
                 ) : (

--- a/app/(base)/arenas/components/DebatingArenaSection.tsx
+++ b/app/(base)/arenas/components/DebatingArenaSection.tsx
@@ -57,9 +57,9 @@ export default function DebatingArenaSection({ onLoaded }: Props) {
     return (
         <div>
             <ArenaSectionHeader status={3} />
-            <div className="mt-4 grid grid-cols-1 gap-6 px-6 sm:grid-cols-2 lg:grid-cols-3">
+            <div className="mt-4 grid grid-cols-1 justify-center gap-6 px-4 sm:sm:[grid-template-columns:repeat(auto-fill,minmax(360px,1fr))]">
                 {arenaListDto?.arenas.length === 0 ? (
-                    <div className="col-span-3 text-center text-gray-500">
+                    <div className="w-full text-center text-gray-500">
                         현재 {GetSectionTitle(status)}이 없습니다.
                     </div>
                 ) : (

--- a/app/(base)/arenas/components/RecruitingArenaCard.tsx
+++ b/app/(base)/arenas/components/RecruitingArenaCard.tsx
@@ -25,7 +25,7 @@ export default function RecruitingArenaCard(props: RecruitingArenaCardProps) {
             className="flex h-full w-full transform flex-col gap-4 rounded-2xl border border-transparent bg-background-300 p-4 text-white shadow-md transition-all duration-200 hover:scale-[1.01] hover:cursor-pointer hover:border-purple-500 hover:shadow-lg hover:shadow-purple-500/30"
             onClick={onClickHandler}
         >
-            <div className="flex flex-col items-center gap-1 sm:flex-row sm:items-center sm:justify-between">
+            <div className="flex flex-row items-center justify-between gap-1">
                 {/* 작성자 정보 */}
                 <div className="flex min-w-0 flex-shrink items-center gap-2 overflow-hidden">
                     <Image
@@ -40,19 +40,19 @@ export default function RecruitingArenaCard(props: RecruitingArenaCardProps) {
                     </span>
                     <TierBadge score={props.creatorScore} size="sm" />
                 </div>
-                <div className="rounded-full bg-background-200 px-3 py-1 text-xs font-semibold text-white">
+                <div className="flex h-6 flex-shrink-0 items-center rounded-full bg-background-200 px-3 text-xs font-semibold">
                     모집중
                 </div>
             </div>
 
             <div className="flex-grow rounded-2xl bg-background-200 p-4">
                 {/* 제목 */}
-                <div className="text-base font-semibold text-white">
+                <div className="break-keep text-base font-semibold text-white">
                     {props.title}
                 </div>
 
                 {/* 설명 */}
-                <div className="line-clamp-3 overflow-hidden text-sm text-gray-300">
+                <div className="line-clamp-3 overflow-hidden break-keep text-sm text-gray-300">
                     {props.description}
                 </div>
             </div>

--- a/app/(base)/arenas/components/RecruitingArenaCard.tsx
+++ b/app/(base)/arenas/components/RecruitingArenaCard.tsx
@@ -22,12 +22,12 @@ export default function RecruitingArenaCard(props: RecruitingArenaCardProps) {
 
     return (
         <div
-            className="w-[670px] transform gap-4 rounded-2xl border border-transparent bg-background-300 p-4 text-white shadow-md transition-all duration-200 hover:scale-[1.01] hover:cursor-pointer hover:border-purple-500 hover:shadow-lg hover:shadow-purple-500/30"
+            className="flex h-full w-full transform flex-col gap-4 rounded-2xl border border-transparent bg-background-300 p-4 text-white shadow-md transition-all duration-200 hover:scale-[1.01] hover:cursor-pointer hover:border-purple-500 hover:shadow-lg hover:shadow-purple-500/30"
             onClick={onClickHandler}
         >
-            <div className="flex items-center justify-between pb-2">
+            <div className="flex flex-col items-center gap-1 sm:flex-row sm:items-center sm:justify-between">
                 {/* 작성자 정보 */}
-                <div className="flex items-center gap-2 text-sm text-white">
+                <div className="flex min-w-0 flex-shrink items-center gap-2 overflow-hidden">
                     <Image
                         src={props.creatorProfileImageUrl}
                         alt="작성자 프로필"
@@ -35,7 +35,9 @@ export default function RecruitingArenaCard(props: RecruitingArenaCardProps) {
                         height={24}
                         className="rounded-full object-cover"
                     />
-                    <span>{props.creatorNickname}</span>
+                    <span className="max-w-[100px] truncate whitespace-nowrap">
+                        {props.creatorNickname}
+                    </span>
                     <TierBadge score={props.creatorScore} size="sm" />
                 </div>
                 <div className="rounded-full bg-background-200 px-3 py-1 text-xs font-semibold text-white">
@@ -43,14 +45,16 @@ export default function RecruitingArenaCard(props: RecruitingArenaCardProps) {
                 </div>
             </div>
 
-            <div className="rounded-2xl bg-background-200 p-4">
+            <div className="flex-grow rounded-2xl bg-background-200 p-4">
                 {/* 제목 */}
                 <div className="text-base font-semibold text-white">
                     {props.title}
                 </div>
 
                 {/* 설명 */}
-                <div className="text-sm text-gray-300">{props.description}</div>
+                <div className="line-clamp-3 overflow-hidden text-sm text-gray-300">
+                    {props.description}
+                </div>
             </div>
 
             {/* 하단 영역 */}

--- a/app/(base)/arenas/components/RecruitingArenaSection.tsx
+++ b/app/(base)/arenas/components/RecruitingArenaSection.tsx
@@ -57,7 +57,7 @@ export default function RecruitingArenaSection({ onLoaded }: Props) {
     return (
         <div>
             <ArenaSectionHeader status={status} />
-            <div className="mt-4 grid grid-cols-1 justify-center gap-6 px-4 sm:sm:[grid-template-columns:repeat(auto-fit,minmax(360px,1fr))]">
+            <div className="mt-4 grid grid-cols-1 justify-center gap-6 px-4 sm:sm:[grid-template-columns:repeat(auto-fill,minmax(500px,1fr))]">
                 {" "}
                 {arenaListDto?.arenas.length === 0 ? (
                     <div className="w-full text-center text-gray-500">

--- a/app/(base)/arenas/components/RecruitingArenaSection.tsx
+++ b/app/(base)/arenas/components/RecruitingArenaSection.tsx
@@ -60,7 +60,7 @@ export default function RecruitingArenaSection({ onLoaded }: Props) {
             <div className="mt-4 grid grid-cols-1 justify-center gap-6 px-4 sm:sm:[grid-template-columns:repeat(auto-fill,minmax(500px,1fr))]">
                 {" "}
                 {arenaListDto?.arenas.length === 0 ? (
-                    <div className="w-full text-center text-gray-500">
+                    <div className="w-full text-left text-gray-500">
                         현재 {GetSectionTitle(status)}이 없습니다.
                     </div>
                 ) : (

--- a/app/(base)/arenas/components/RecruitingArenaSection.tsx
+++ b/app/(base)/arenas/components/RecruitingArenaSection.tsx
@@ -57,9 +57,10 @@ export default function RecruitingArenaSection({ onLoaded }: Props) {
     return (
         <div>
             <ArenaSectionHeader status={status} />
-            <div className="mt-4 grid grid-cols-1 gap-6 px-6 sm:grid-cols-2">
+            <div className="mt-4 grid grid-cols-1 justify-center gap-6 px-4 sm:sm:[grid-template-columns:repeat(auto-fit,minmax(360px,1fr))]">
+                {" "}
                 {arenaListDto?.arenas.length === 0 ? (
-                    <div className="col-span-3 text-center text-gray-500">
+                    <div className="w-full text-center text-gray-500">
                         현재 {GetSectionTitle(status)}이 없습니다.
                     </div>
                 ) : (

--- a/app/(base)/arenas/components/SelectedArenaSection.tsx
+++ b/app/(base)/arenas/components/SelectedArenaSection.tsx
@@ -77,12 +77,10 @@ export default function SelectedArenaSection({
         <div>
             <ArenaSectionHeader status={status} />
             <div
-                className={`grid grid-cols-1 sm:grid-cols-2 ${
-                    [1, 5].includes(status) ? "" : "lg:grid-cols-3"
-                } mt-4 gap-6 px-6`}
+                className={`mt-4 grid grid-cols-1 justify-center gap-6 px-4 sm:sm:[grid-template-columns:repeat(auto-fill,minmax(${[1, 5].includes(status) ? 500 : 360}px,1fr))]`}
             >
                 {arenaListDto?.arenas.length === 0 ? (
-                    <div className="col-span-3 text-center text-gray-500">
+                    <div className="w-full text-center text-gray-500">
                         현재 {GetSectionTitle(status)}이 없습니다.
                     </div>
                 ) : (

--- a/app/(base)/arenas/components/SelectedArenaSection.tsx
+++ b/app/(base)/arenas/components/SelectedArenaSection.tsx
@@ -80,7 +80,7 @@ export default function SelectedArenaSection({
                 className={`mt-4 grid grid-cols-1 justify-center gap-6 px-4 sm:sm:[grid-template-columns:repeat(auto-fill,minmax(${[1, 5].includes(status) ? 500 : 360}px,1fr))]`}
             >
                 {arenaListDto?.arenas.length === 0 ? (
-                    <div className="w-full text-center text-gray-500">
+                    <div className="w-full text-left text-gray-500">
                         현재 {GetSectionTitle(status)}이 없습니다.
                     </div>
                 ) : (

--- a/app/(base)/arenas/components/VoteStatusBar.tsx
+++ b/app/(base)/arenas/components/VoteStatusBar.tsx
@@ -9,7 +9,7 @@ type VoteStatusBarProps = {
 export default function VoteStatusBar(props: VoteStatusBarProps) {
     return (
         <div className="relative mt-4 flex h-3 w-full overflow-hidden rounded-lg">
-            {props.leftPercent === 0 ? ( //Todo: voteCount로 변경하기
+            {props.voteCount === 0 ? (
                 <>
                     <div
                         className="h-full w-full rounded-lg"

--- a/app/(base)/arenas/components/VotingArenaCard.tsx
+++ b/app/(base)/arenas/components/VotingArenaCard.tsx
@@ -7,10 +7,12 @@ import { useRouter } from "next/navigation";
 type VotingArenaCardProps = {
     id: number;
     title: string;
+
     creatorNickname: string;
     creatorScore: number;
     challengerNickname: string | null;
     challengerScore: number | null;
+
     voteEndDate: Date;
     voteCount: number;
 };
@@ -23,35 +25,40 @@ export default function VotingArenaCard(props: VotingArenaCardProps) {
 
     return (
         <div
-            className="w-[440px] transform gap-4 rounded-2xl border border-transparent bg-background-300 p-4 text-white shadow-md transition-all duration-200 hover:scale-[1.01] hover:cursor-pointer hover:border-purple-500 hover:shadow-lg hover:shadow-purple-500/30"
+            className="flex h-full w-full transform flex-col gap-4 rounded-2xl border border-transparent bg-background-300 p-4 text-white shadow-md transition-all duration-200 hover:scale-[1.01] hover:cursor-pointer hover:border-purple-500 hover:shadow-lg hover:shadow-purple-500/30"
             onClick={onClickHandler}
         >
-            <div className="flex items-center justify-between">
-                <div className="line-clamp-2 text-lg font-bold">
+            <div className="flex flex-row items-start justify-between gap-1">
+                <div className="line-clamp-2 min-h-[3.5rem] break-keep text-lg font-bold">
                     {props.title}
                 </div>
-                <div className="rounded-full bg-purple-500 px-3 py-1 text-xs font-semibold text-white">
+                <div className="flex h-6 flex-shrink-0 items-center rounded-full bg-purple-500 px-3 text-xs font-semibold">
                     투표중
                 </div>
             </div>
 
-            <div className="m-2 mt-2 flex items-center justify-between gap-4 text-sm text-gray-100">
-                <div className="flex items-center gap-2">
-                    <span>{props.creatorNickname}</span>
+            <div className="flex items-center justify-between text-sm text-gray-100">
+                {/* 작성자 */}
+                <div className="flex min-w-0 flex-shrink items-center gap-2 overflow-hidden">
+                    <span className="max-w-[100px] truncate whitespace-nowrap">
+                        {props.creatorNickname}
+                    </span>
                     <TierBadge score={props.creatorScore} size="sm" />
                 </div>
 
                 <span className="mx-2 text-gray-400">vs</span>
 
                 {/* 도전자 */}
-                <div className="flex items-center gap-2">
-                    <span>{props.challengerNickname}</span>
+                <div className="flex min-w-0 flex-shrink items-center gap-2 overflow-hidden">
+                    <span className="max-w-[100px] truncate whitespace-nowrap">
+                        {props.challengerNickname}
+                    </span>
                     <TierBadge score={props.challengerScore || 0} size="sm" />
                 </div>
             </div>
 
-            <div className="mt-4 flex items-center justify-between text-sm text-gray-300">
-                <div className="flex items-center gap-1">
+            <div className="mt-2 flex items-center justify-between">
+                <div className="flex items-center gap-1 text-sm text-gray-400">
                     <Image
                         src="/icons/infoCalendar.svg"
                         alt="달력 아이콘"
@@ -60,9 +67,7 @@ export default function VotingArenaCard(props: VotingArenaCardProps) {
                         className="object-contain"
                     />
                     <span className="text-gray-400">
-                        투표 종료:{" "}
                         {props.voteEndDate.toLocaleDateString("ko-KR", {
-                            year: "numeric",
                             month: "long",
                             day: "numeric",
                             hour: "2-digit",
@@ -78,9 +83,7 @@ export default function VotingArenaCard(props: VotingArenaCardProps) {
                         height={18}
                         className="object-contain"
                     />
-                    <span className="text-gray-400">
-                        {props.voteCount}명 투표
-                    </span>
+                    <span className="text-gray-400">{props.voteCount}명</span>
                 </div>
             </div>
         </div>

--- a/app/(base)/arenas/components/VotingArenaSection.tsx
+++ b/app/(base)/arenas/components/VotingArenaSection.tsx
@@ -96,9 +96,9 @@ export default function VotingArenaSection({ onLoaded }: Props) {
     return (
         <div>
             <ArenaSectionHeader status={4} />
-            <div className="mt-4 grid grid-cols-1 gap-6 px-6 sm:grid-cols-2 lg:grid-cols-3">
+            <div className="mt-4 grid grid-cols-1 justify-center gap-6 px-4 sm:sm:[grid-template-columns:repeat(auto-fill,minmax(360px,1fr))]">
                 {arenaListDto?.arenas.length === 0 ? (
-                    <div className="col-span-3 text-center text-gray-500">
+                    <div className="w-full text-center text-gray-500">
                         현재 {GetSectionTitle(status)}이 없습니다.
                     </div>
                 ) : (

--- a/app/(base)/arenas/components/VotingArenaSection.tsx
+++ b/app/(base)/arenas/components/VotingArenaSection.tsx
@@ -98,7 +98,7 @@ export default function VotingArenaSection({ onLoaded }: Props) {
             <ArenaSectionHeader status={4} />
             <div className="mt-4 grid grid-cols-1 justify-center gap-6 px-4 sm:sm:[grid-template-columns:repeat(auto-fill,minmax(360px,1fr))]">
                 {arenaListDto?.arenas.length === 0 ? (
-                    <div className="w-full text-center text-gray-500">
+                    <div className="w-full text-left text-gray-500 sm:text-left">
                         현재 {GetSectionTitle(status)}이 없습니다.
                     </div>
                 ) : (

--- a/app/(base)/arenas/components/WaitingArenaCard.tsx
+++ b/app/(base)/arenas/components/WaitingArenaCard.tsx
@@ -22,35 +22,40 @@ export default function WaitingArenaCard(props: WaitingArenaCardProps) {
 
     return (
         <div
-            className="w-[440px] transform gap-4 rounded-2xl border border-transparent bg-background-300 p-4 text-white shadow-md transition-all duration-200 hover:scale-[1.01] hover:cursor-pointer hover:border-purple-500 hover:shadow-lg hover:shadow-purple-500/30"
+            className="flex h-full w-full transform flex-col gap-4 rounded-2xl border border-transparent bg-background-300 p-4 text-white shadow-md transition-all duration-200 hover:scale-[1.01] hover:cursor-pointer hover:border-purple-500 hover:shadow-lg hover:shadow-purple-500/30"
             onClick={onClickHandler}
         >
-            <div className="flex items-center justify-between">
-                <div className="line-clamp-2 text-lg font-bold">
+            <div className="flex flex-row items-start justify-between gap-1">
+                <div className="line-clamp-2 min-h-[3.5rem] break-keep text-lg font-bold">
                     {props.title}
                 </div>
-                <div className="rounded-full bg-background-200 px-3 py-1 text-xs font-semibold text-white">
+                <div className="flex h-6 flex-shrink-0 items-center rounded-full bg-background-200 px-3 text-xs font-semibold">
                     대기중
                 </div>
             </div>
 
-            <div className="m-4 mt-4 flex items-center justify-between gap-4 text-sm text-gray-100">
-                <div className="flex items-center gap-2">
-                    <span>{props.creatorNickname}</span>
+            <div className="flex items-center justify-between text-sm text-gray-100">
+                {/* 작성자 */}
+                <div className="flex min-w-0 flex-shrink items-center gap-2 overflow-hidden">
+                    <span className="max-w-[100px] truncate whitespace-nowrap">
+                        {props.creatorNickname}
+                    </span>
                     <TierBadge score={props.creatorScore} size="sm" />
                 </div>
 
                 <span className="mx-2 text-gray-400">vs</span>
 
                 {/* 도전자 */}
-                <div className="flex items-center gap-2">
-                    <span>{props.challengerNickname}</span>
+                <div className="flex min-w-0 flex-shrink items-center gap-2 overflow-hidden">
+                    <span className="max-w-[100px] truncate whitespace-nowrap">
+                        {props.challengerNickname}
+                    </span>
                     <TierBadge score={props.challengerScore || 0} size="sm" />
                 </div>
             </div>
 
-            <div className="mt-4 flex items-center justify-between text-sm text-gray-300">
-                <div className="flex items-center gap-1">
+            <div className="mt-2 flex items-center justify-between">
+                <div className="flex items-center gap-1 text-sm text-gray-400">
                     <Image
                         src="/icons/infoCalendar.svg"
                         alt="달력 아이콘"

--- a/app/(base)/arenas/components/WaitingArenaSection.tsx
+++ b/app/(base)/arenas/components/WaitingArenaSection.tsx
@@ -57,9 +57,9 @@ export default function WaitingArenaSection({ onLoaded }: Props) {
     return (
         <div>
             <ArenaSectionHeader status={2} />
-            <div className="mt-4 grid grid-cols-1 gap-6 px-6 sm:grid-cols-2 lg:grid-cols-3">
+            <div className="mt-4 grid grid-cols-1 justify-center gap-6 px-4 sm:sm:[grid-template-columns:repeat(auto-fill,minmax(360px,1fr))]">
                 {arenaListDto?.arenas.length === 0 ? (
-                    <div className="col-span-3 text-center text-gray-500">
+                    <div className="w-full text-center text-gray-500">
                         현재 {GetSectionTitle(status)}이 없습니다.
                     </div>
                 ) : (

--- a/app/(base)/arenas/components/WaitingArenaSection.tsx
+++ b/app/(base)/arenas/components/WaitingArenaSection.tsx
@@ -59,7 +59,7 @@ export default function WaitingArenaSection({ onLoaded }: Props) {
             <ArenaSectionHeader status={2} />
             <div className="mt-4 grid grid-cols-1 justify-center gap-6 px-4 sm:sm:[grid-template-columns:repeat(auto-fill,minmax(360px,1fr))]">
                 {arenaListDto?.arenas.length === 0 ? (
-                    <div className="w-full text-center text-gray-500">
+                    <div className="w-full text-left text-gray-500">
                         현재 {GetSectionTitle(status)}이 없습니다.
                     </div>
                 ) : (

--- a/app/(base)/layout.tsx
+++ b/app/(base)/layout.tsx
@@ -1,5 +1,6 @@
 // app/(base)/layout.tsx
-import HeaderWrapper from "../components/HeaderWrapper"; // ✅ CSR Header Wrapper
+// import HeaderWrapper from "../components/HeaderWrapper"; // ✅ CSR Header Wrapper
+import Header from "../components/Header";
 import Footer from "../components/Footer";
 import GlobalAttendanceToast from "./components/GlobalAttendanceToast";
 import "../globals.css";
@@ -13,8 +14,8 @@ export default function BaseLayout({
 }) {
     return (
         <>
-            <HeaderWrapper /> {/* CSR로만 렌더링됨 */}
-            <main className="mx-auto max-w-[1480px] px-10 font-sans text-font-100">
+            <Header /> {/* CSR로만 렌더링됨 */}
+            <main className="mx-auto max-w-[1480px] font-sans text-font-100 sm:px-10">
                 <LottieLoaderWrapper />
                 <GlobalAttendanceToast />
 

--- a/app/components/ModalWrapper.tsx
+++ b/app/components/ModalWrapper.tsx
@@ -29,11 +29,11 @@ export default function ModalWrapper(modalWrapperProps: ModalWrapperProps) {
 
     return createPortal(
         <div
-            className="fixed inset-0 z-50 flex flex-col items-center justify-center bg-black/50"
+            className="fixed inset-0 z-50 flex items-center justify-center bg-black/50 px-2 sm:px-4"
             onClick={modalWrapperProps.onClose}
         >
             <div
-                className="bg-background-300 text-font-100 rounded-xl p-2.5 shadow-xl"
+                className="max-h-[90vh] w-full max-w-[480px] overflow-y-auto rounded-xl bg-background-300 p-6 text-font-100 shadow-xl"
                 onClick={(e) => e.stopPropagation()}
             >
                 {modalWrapperProps.children}

--- a/package-lock.json
+++ b/package-lock.json
@@ -40,6 +40,7 @@
             },
             "devDependencies": {
                 "@eslint/eslintrc": "^3",
+                "@tailwindcss/line-clamp": "^0.4.4",
                 "@tailwindcss/postcss": "^4",
                 "@types/js-cookie": "^3.0.6",
                 "@types/node": "^20",
@@ -240,10 +241,11 @@
             }
         },
         "node_modules/@eslint/plugin-kit": {
-            "version": "0.3.3",
-            "resolved": "https://registry.npmjs.org/@eslint/plugin-kit/-/plugin-kit-0.3.3.tgz",
-            "integrity": "sha512-1+WqvgNMhmlAambTvT3KPtCl/Ibr68VldY2XY40SL1CE0ZXiakFR/cbTspaF5HsnpDMvcYYoJHfl4980NBjGag==",
+            "version": "0.3.4",
+            "resolved": "https://registry.npmjs.org/@eslint/plugin-kit/-/plugin-kit-0.3.4.tgz",
+            "integrity": "sha512-Ul5l+lHEcw3L5+k8POx6r74mxEYKG5kOb6Xpy2gCRW6zweT6TEhAf8vhxGgjhqrd/VO/Dirhsb+1hNpD1ue9hw==",
             "dev": true,
+            "license": "Apache-2.0",
             "dependencies": {
                 "@eslint/core": "^0.15.1",
                 "levn": "^0.4.1"
@@ -1146,6 +1148,16 @@
             "integrity": "sha512-JQ5TuMi45Owi4/BIMAJBoSQoOJu12oOk/gADqlcUL9JEdHB8vyjUSsxqeNXnmXHjYKMi2WcYtezGEEhqUI/E2g==",
             "dependencies": {
                 "tslib": "^2.8.0"
+            }
+        },
+        "node_modules/@tailwindcss/line-clamp": {
+            "version": "0.4.4",
+            "resolved": "https://registry.npmjs.org/@tailwindcss/line-clamp/-/line-clamp-0.4.4.tgz",
+            "integrity": "sha512-5U6SY5z8N42VtrCrKlsTAA35gy2VSyYtHWCsg1H87NU1SXnEfekTVlrga9fzUDrrHcGi2Lb5KenUWb4lRQT5/g==",
+            "dev": true,
+            "license": "MIT",
+            "peerDependencies": {
+                "tailwindcss": ">=2.0.0 || >=3.0.0 || >=3.0.0-alpha.1"
             }
         },
         "node_modules/@tailwindcss/node": {

--- a/package.json
+++ b/package.json
@@ -41,6 +41,7 @@
     },
     "devDependencies": {
         "@eslint/eslintrc": "^3",
+        "@tailwindcss/line-clamp": "^0.4.4",
         "@tailwindcss/postcss": "^4",
         "@types/js-cookie": "^3.0.6",
         "@types/node": "^20",


### PR DESCRIPTION
## ✨ 작업 개요
투기장 탐색 페이지에 반응형 디자인을 적용합니다.

## ✅ 상세 내용

- [x] 투기장 탐색 페이지/도전장 작성 모달에 각각 모바일용/md 사이즈용 반응형 디자인 적용
- [x] 투기장 생성 모달에 모바일용 반응형 디자인 적용 
- [x] 투기장 탐색 페이지에서 상태별로 보기 시 투표 정보를 잘못 가져오던 현상 수정
- [x] 너비에 상관 없이 투기장 설명이 3줄 이상 넘어갈 경우 말줄임표로 생략하도록 수정
- [x] HeaderWrapper 사용하지 않도록 변경
- [x] 투기장 헤더에도 break-keep 적용
- [x] 투기장 제목 줄바꿈 일어나지 않도록 모바일 환경에서 폰트 사이즈 조정
- [x] 전체 페이지 레이아웃 모바일 환경에서 margin 적게 수정

## 📸 스크린샷 (선택)
<img width="874" height="768" alt="image" src="https://github.com/user-attachments/assets/6f9a6a7e-1ced-4731-b73c-7773c7608e5c" />
<img width="379" height="816" alt="image" src="https://github.com/user-attachments/assets/ba06af30-f060-4ef7-a8fc-8b34456f0325" />
<img width="379" height="817" alt="image" src="https://github.com/user-attachments/assets/a320ad0a-08a2-4c1c-bdf9-5e498f1056b4" />


## 🧪 확인 사항

-   [x] 정상적으로 동작하는지 직접 테스트해봤나요?
-   [x] 기능 추가/수정 후 UI나 비즈니스 로직에 영향은 없나요?
-   [x] 다른 환경에서 화면 정상적으로 출력되는지 확인 바랍니다.

## 🙏 기타 참고 사항

## 이슈 관리

close #196 
