### PR TITLE
[fix/#233] 게임 탐색 페이지 버그 수정

### DIFF
--- a/app/(base)/games/components/GameCard.tsx
+++ b/app/(base)/games/components/GameCard.tsx
@@ -60,7 +60,7 @@ export default function GameCard({
             <div className="relative flex w-full flex-col justify-between gap-2 px-4 py-3">
                 {/* 제목 */}
 
-                <h2 className="line-clamp-2 text-h3 font-semibold text-font-100">
+                <h2 className="line-clamp-2 h-[3.2rem] text-h3 font-semibold text-font-100">
                     {title}
                 </h2>
 

--- a/backend/game/application/usecase/GetFilteredGamesUsecase.ts
+++ b/backend/game/application/usecase/GetFilteredGamesUsecase.ts
@@ -31,10 +31,22 @@ export class GetFilteredGamesUsecase {
         const games = await this.gameRepository.findAll(filter);
         const gameIds = games.map((g) => g.id);
 
-        // 모든 리뷰 가져오기
-        const allReviews = await this.reviewRepository.findAllByGameIds(
-            gameIds
+        const gamesTotalCount = await this.gameRepository.count(
+            new GameFilter(
+                dto.genreId,
+                dto.themeId,
+                dto.platformId,
+                dto.keyword,
+                dto.sort,
+                false,
+                0,
+                undefined
+            )
         );
+
+        // 모든 리뷰 가져오기
+        const allReviews =
+            await this.reviewRepository.findAllByGameIds(gameIds);
 
         // 리뷰 통계 계산
         const stats: Record<
@@ -107,7 +119,7 @@ export class GetFilteredGamesUsecase {
 
         return {
             data: paged,
-            totalCount: enrichedGames.length,
+            totalCount: gamesTotalCount,
         };
     }
 }


### PR DESCRIPTION
## ✨ 작업 개요
게임 탐색 페이지에 관련된 버그를 수정합니다.


## ✅ 상세 내용
- [x] 게임 탐색 API에서 최신순 GET 요청만 total count가 6으로 고정되는 문제 수정
- [x] 게임 탐색 카드의 제목 높이 고정하여 다른 컴포넌트의 위치가 변하지 않도록 수정

## 📸 스크린샷 (선택)

## 🧪 확인 사항

-   [x] 정상적으로 동작하는지 직접 테스트해봤나요?
-   [x] 기능 추가/수정 후 UI나 비즈니스 로직에 영향은 없나요?
-   [x] 다양한 환경에서 정상적으로 작동하는지 확인 부탁드립니다.

## 🙏 기타 참고 사항

## 이슈 관리

close #233 