### PR TITLE
[style/#296] 마이페이지 위시리스트 탭 게임 카드 레이아웃을 게임 탐색 페이지와 통일

### DIFF
--- a/app/(base)/games/components/GameCardList.tsx
+++ b/app/(base)/games/components/GameCardList.tsx
@@ -2,7 +2,7 @@ import React from "react";
 import GameCard from "./GameCard";
 import Image from "next/image";
 
-interface GameCardData {
+export type GameCardData = {
     id: number;
     platform: string;
     title: string;
@@ -10,11 +10,11 @@ interface GameCardData {
     developer: string;
     thumbnail: string;
     reviewCount: number;
-}
+};
 
-interface GameCardListProps {
+type GameCardListProps = {
     games: GameCardData[];
-}
+};
 
 export default function GameCardList({ games }: GameCardListProps) {
     if (games.length === 0) {

--- a/app/(base)/profile/components/tabs/ProfileWishlistTab.tsx
+++ b/app/(base)/profile/components/tabs/ProfileWishlistTab.tsx
@@ -1,25 +1,17 @@
 "use client";
 
-import GameCardList from "@/app/(base)/games/components/GameCardList";
+import GameCardList, {
+    GameCardData,
+} from "@/app/(base)/games/components/GameCardList";
 import Pager from "@/app/components/Pager";
 
-interface Game {
-    id: number;
-    title: string;
-    developer: string;
-    thumbnail: string;
-    platform: string;
-    expertRating: number;
-    reviewCount: number;
-}
-
-interface Props {
-    games: Game[];
+type Props = {
+    games: GameCardData[];
     pages: number[];
     currentPage: number;
     endPage: number;
     onPageChange: (page: number) => void;
-}
+};
 
 export default function ProfileWishlistTab({
     games,

--- a/app/(base)/profile/components/tabs/ProfileWishlistTab.tsx
+++ b/app/(base)/profile/components/tabs/ProfileWishlistTab.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import GameCard from "@/app/(base)/games/components/GameCard";
+import GameCardList from "@/app/(base)/games/components/GameCardList";
 import Pager from "@/app/components/Pager";
 
 interface Game {
@@ -38,12 +38,7 @@ export default function ProfileWishlistTab({
                 </p>
             ) : (
                 <>
-                    {/* 820px → md 로 교체 */}
-                    <div className="grid grid-cols-1 gap-6 md:grid-cols-2">
-                        {games.map((game) => (
-                            <GameCard key={game.id} {...game} />
-                        ))}
-                    </div>
+                    <GameCardList games={games} />
 
                     {endPage > 1 && (
                         <Pager

--- a/app/(base)/profile/components/tabs/__tests__/ProfileWishlistTab.test.tsx
+++ b/app/(base)/profile/components/tabs/__tests__/ProfileWishlistTab.test.tsx
@@ -1,0 +1,78 @@
+// @vitest-environment jsdom
+import { describe, it, expect, vi } from "vitest";
+import { render, screen } from "@testing-library/react";
+import ProfileWishlistTab from "../ProfileWishlistTab";
+
+vi.mock("@/app/(base)/games/components/GameCardList", () => ({
+    default: ({ games }: { games: unknown[] }) => (
+        <div data-testid="game-card-list" data-count={games.length} />
+    ),
+}));
+
+vi.mock("@/app/components/Pager", () => ({
+    default: () => <div data-testid="pager" />,
+}));
+
+const defaultProps = {
+    games: [],
+    pages: [],
+    currentPage: 1,
+    endPage: 1,
+    onPageChange: vi.fn(),
+};
+
+const sampleGames = [
+    {
+        id: 1,
+        title: "사이버펑크 2077",
+        developer: "CD Projekt Red",
+        thumbnail: "/img1.jpg",
+        platform: "PC",
+        expertRating: 8.5,
+        reviewCount: 42,
+    },
+    {
+        id: 2,
+        title: "엘든 링",
+        developer: "FromSoftware",
+        thumbnail: "/img2.jpg",
+        platform: "PC",
+        expertRating: 9.5,
+        reviewCount: 100,
+    },
+];
+
+describe("ProfileWishlistTab", () => {
+    it("게임이 없을 때 위시리스트 고유 빈 상태 메시지를 표시한다", () => {
+        render(<ProfileWishlistTab {...defaultProps} />);
+        expect(
+            screen.getByText("위시리스트에 등록된 게임이 없습니다."),
+        ).toBeDefined();
+    });
+
+    it("게임이 있을 때 GameCardList를 렌더링한다", () => {
+        render(
+            <ProfileWishlistTab
+                {...defaultProps}
+                games={sampleGames}
+                pages={[1]}
+                endPage={1}
+            />,
+        );
+        expect(screen.getByTestId("game-card-list")).toBeDefined();
+    });
+
+    it("게임이 있을 때 빈 상태 메시지를 표시하지 않는다", () => {
+        render(
+            <ProfileWishlistTab
+                {...defaultProps}
+                games={sampleGames}
+                pages={[1]}
+                endPage={1}
+            />,
+        );
+        expect(
+            screen.queryByText("위시리스트에 등록된 게임이 없습니다."),
+        ).toBeNull();
+    });
+});

--- a/app/(base)/profile/components/tabs/__tests__/ProfileWishlistTab.test.tsx
+++ b/app/(base)/profile/components/tabs/__tests__/ProfileWishlistTab.test.tsx
@@ -60,6 +60,8 @@ describe("ProfileWishlistTab", () => {
             />,
         );
         expect(screen.getByTestId("game-card-list")).toBeDefined();
+        const list = screen.getByTestId("game-card-list");
+        expect(list.getAttribute("data-count")).toBe("2");
     });
 
     it("게임이 있을 때 빈 상태 메시지를 표시하지 않는다", () => {
@@ -74,5 +76,29 @@ describe("ProfileWishlistTab", () => {
         expect(
             screen.queryByText("위시리스트에 등록된 게임이 없습니다."),
         ).toBeNull();
+    });
+
+    it("endPage가 1보다 클 때 Pager를 렌더링한다", () => {
+        render(
+            <ProfileWishlistTab
+                {...defaultProps}
+                games={sampleGames}
+                pages={[1, 2]}
+                endPage={2}
+            />,
+        );
+        expect(screen.getByTestId("pager")).toBeDefined();
+    });
+
+    it("endPage가 1일 때 Pager를 렌더링하지 않는다", () => {
+        render(
+            <ProfileWishlistTab
+                {...defaultProps}
+                games={sampleGames}
+                pages={[1]}
+                endPage={1}
+            />,
+        );
+        expect(screen.queryByTestId("pager")).toBeNull();
     });
 });

--- a/backend/wishlist/application/usecase/GetWishlistsUsecase.ts
+++ b/backend/wishlist/application/usecase/GetWishlistsUsecase.ts
@@ -6,7 +6,7 @@ import { GetWishlistsDto } from "./dto/GetWishlistsDto";
 import { GetWishlistsResultDto } from "./dto/GetWishlistsResultDto";
 import { WishlistFilter } from "../../domain/filters/WishlistFilter";
 
-const ITEMS_PER_PAGE = 4; // 페이지당 아이템 수
+const ITEMS_PER_PAGE = 5; // 페이지당 아이템 수
 
 export class GetWishlistsUsecase {
     constructor(

--- a/docs/superpowers/plans/2026-04-07-wishlist-game-card-layout-unification.md
+++ b/docs/superpowers/plans/2026-04-07-wishlist-game-card-layout-unification.md
@@ -1,0 +1,260 @@
+# Wishlist Game Card Layout Unification Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** `ProfileWishlistTab`의 수동 grid 레이아웃을 `GameCardList` 컴포넌트로 교체하여 위시리스트와 게임 탐색 페이지의 게임 카드 레이아웃을 통일한다.
+
+**Architecture:** 빈 상태 처리는 `ProfileWishlistTab`에 유지(위시리스트 고유 메시지 보존)하고, 게임 목록 렌더링만 `GameCardList`로 위임한다. `GameCardList`의 `grid-cols-2 lg:grid-cols-5` 레이아웃을 재사용하여 단일 출처를 만든다.
+
+**Tech Stack:** Next.js 15 App Router, React 19, TypeScript, TailwindCSS 3, Vitest 4, Testing Library
+
+---
+
+## File Structure
+
+| 파일 | 역할 | 작업 |
+|------|------|------|
+| `app/(base)/profile/components/tabs/ProfileWishlistTab.tsx` | 위시리스트 탭 UI 컴포넌트 | **수정** — `GameCard` → `GameCardList` 교체 |
+| `app/(base)/profile/components/tabs/__tests__/ProfileWishlistTab.test.tsx` | `ProfileWishlistTab` 단위 테스트 | **신규 생성** |
+
+참고 파일 (수정 없음):
+- `app/(base)/games/components/GameCardList.tsx` — 재사용할 그리드 컴포넌트
+- `app/(base)/games/components/GameCard.tsx` — `GameCardList` 내부에서 사용
+
+---
+
+### Task 1: 실패하는 테스트 작성
+
+**Files:**
+- Create: `app/(base)/profile/components/tabs/__tests__/ProfileWishlistTab.test.tsx`
+
+- [ ] **Step 1: `__tests__` 디렉토리를 확인하고 테스트 파일 생성**
+
+```tsx
+// @vitest-environment jsdom
+import { describe, it, expect, vi } from "vitest";
+import { render, screen } from "@testing-library/react";
+import ProfileWishlistTab from "../ProfileWishlistTab";
+
+vi.mock("@/app/(base)/games/components/GameCardList", () => ({
+    default: ({ games }: { games: unknown[] }) => (
+        <div data-testid="game-card-list" data-count={games.length} />
+    ),
+}));
+
+vi.mock("@/app/components/Pager", () => ({
+    default: () => <div data-testid="pager" />,
+}));
+
+const defaultProps = {
+    games: [],
+    pages: [],
+    currentPage: 1,
+    endPage: 1,
+    onPageChange: vi.fn(),
+};
+
+const sampleGames = [
+    {
+        id: 1,
+        title: "사이버펑크 2077",
+        developer: "CD Projekt Red",
+        thumbnail: "/img1.jpg",
+        platform: "PC",
+        expertRating: 8.5,
+        reviewCount: 42,
+    },
+    {
+        id: 2,
+        title: "엘든 링",
+        developer: "FromSoftware",
+        thumbnail: "/img2.jpg",
+        platform: "PC",
+        expertRating: 9.5,
+        reviewCount: 100,
+    },
+];
+
+describe("ProfileWishlistTab", () => {
+    it("게임이 없을 때 위시리스트 고유 빈 상태 메시지를 표시한다", () => {
+        render(<ProfileWishlistTab {...defaultProps} />);
+        expect(
+            screen.getByText("위시리스트에 등록된 게임이 없습니다."),
+        ).toBeDefined();
+    });
+
+    it("게임이 있을 때 GameCardList를 렌더링한다", () => {
+        render(
+            <ProfileWishlistTab
+                {...defaultProps}
+                games={sampleGames}
+                pages={[1]}
+                endPage={1}
+            />,
+        );
+        expect(screen.getByTestId("game-card-list")).toBeDefined();
+    });
+
+    it("게임이 있을 때 빈 상태 메시지를 표시하지 않는다", () => {
+        render(
+            <ProfileWishlistTab
+                {...defaultProps}
+                games={sampleGames}
+                pages={[1]}
+                endPage={1}
+            />,
+        );
+        expect(
+            screen.queryByText("위시리스트에 등록된 게임이 없습니다."),
+        ).toBeNull();
+    });
+});
+```
+
+- [ ] **Step 2: 테스트 실행 — 2번 케이스가 FAIL인지 확인**
+
+```bash
+npx vitest run app/\(base\)/profile/components/tabs/__tests__/ProfileWishlistTab.test.tsx
+```
+
+Expected output:
+```
+FAIL  app/(base)/profile/components/tabs/__tests__/ProfileWishlistTab.test.tsx
+ × 게임이 있을 때 GameCardList를 렌더링한다
+```
+
+1번과 3번은 PASS, 2번만 FAIL이어야 함 (현재 구현이 `GameCard`를 직접 사용하므로 `data-testid="game-card-list"`가 없음).
+
+---
+
+### Task 2: ProfileWishlistTab 구현 수정
+
+**Files:**
+- Modify: `app/(base)/profile/components/tabs/ProfileWishlistTab.tsx`
+
+- [ ] **Step 3: `ProfileWishlistTab.tsx` 수정**
+
+현재 파일 전체를 아래로 교체:
+
+```tsx
+"use client";
+
+import GameCardList from "@/app/(base)/games/components/GameCardList";
+import Pager from "@/app/components/Pager";
+
+interface Game {
+    id: number;
+    title: string;
+    developer: string;
+    thumbnail: string;
+    platform: string;
+    expertRating: number;
+    reviewCount: number;
+}
+
+interface Props {
+    games: Game[];
+    pages: number[];
+    currentPage: number;
+    endPage: number;
+    onPageChange: (page: number) => void;
+}
+
+export default function ProfileWishlistTab({
+    games,
+    pages,
+    currentPage,
+    endPage,
+    onPageChange,
+}: Props) {
+    return (
+        <div className="flex w-full flex-col gap-6 rounded-xl bg-background-400 p-6 shadow">
+            <h2 className="mb-2 text-lg font-semibold">위시리스트 목록</h2>
+
+            {games.length === 0 ? (
+                <p className="text-sm text-font-200">
+                    위시리스트에 등록된 게임이 없습니다.
+                </p>
+            ) : (
+                <>
+                    <GameCardList games={games} />
+
+                    {endPage > 1 && (
+                        <Pager
+                            currentPage={currentPage}
+                            pages={pages}
+                            endPage={endPage}
+                            onPageChange={onPageChange}
+                        />
+                    )}
+                </>
+            )}
+        </div>
+    );
+}
+```
+
+핵심 변경점:
+- `import GameCard from "@/app/(base)/games/components/GameCard"` → 삭제
+- `import GameCardList from "@/app/(base)/games/components/GameCardList"` → 추가
+- `<div className="grid grid-cols-1 gap-6 md:grid-cols-2"> ... </div>` → `<GameCardList games={games} />` 로 교체
+
+- [ ] **Step 4: 테스트 재실행 — 3/3 PASS 확인**
+
+```bash
+npx vitest run app/\(base\)/profile/components/tabs/__tests__/ProfileWishlistTab.test.tsx
+```
+
+Expected output:
+```
+PASS  app/(base)/profile/components/tabs/__tests__/ProfileWishlistTab.test.tsx
+ ✓ 게임이 없을 때 위시리스트 고유 빈 상태 메시지를 표시한다
+ ✓ 게임이 있을 때 GameCardList를 렌더링한다
+ ✓ 게임이 있을 때 빈 상태 메시지를 표시하지 않는다
+
+Test Files  1 passed (1)
+Tests       3 passed (3)
+```
+
+- [ ] **Step 5: 전체 테스트 suite 실행 — 기존 테스트 회귀 없음 확인**
+
+```bash
+npm test
+```
+
+Expected: 기존 전체 테스트 통과 + 신규 3개 추가 통과.
+
+- [ ] **Step 6: lint 통과 확인**
+
+```bash
+npm run lint
+```
+
+Expected: 에러 없음.
+
+- [ ] **Step 7: 커밋**
+
+```bash
+git add app/\(base\)/profile/components/tabs/ProfileWishlistTab.tsx app/\(base\)/profile/components/tabs/__tests__/ProfileWishlistTab.test.tsx
+git commit -m "[style/#296] 위시리스트 탭 게임 카드 레이아웃을 GameCardList로 통일"
+```
+
+---
+
+## Self-Review
+
+### Spec Coverage 확인
+
+| 스펙 요구사항 | 커버 Task |
+|--------------|-----------|
+| `ProfileWishlistTab`에서 수동 grid div + GameCard 반복 렌더링을 `GameCardList`로 교체 | Task 2, Step 3 |
+| 빈 상태 메시지("위시리스트에 등록된 게임이 없습니다")는 위시리스트 고유 메시지 유지 | Task 1 (테스트로 보호), Task 2 (구현 유지) |
+
+### Placeholder 스캔
+
+없음. 모든 step에 실제 코드 포함.
+
+### 타입 일관성 확인
+
+- `Game` 인터페이스: `ProfileWishlistTab.tsx`의 기존 정의 그대로 유지
+- `GameCardList`의 `GameCardData` 인터페이스와 필드 완전 일치 (`id`, `title`, `developer`, `thumbnail`, `platform`, `expertRating`, `reviewCount`)

--- a/docs/superpowers/specs/2026-04-07-wishlist-game-card-layout-unification-design.md
+++ b/docs/superpowers/specs/2026-04-07-wishlist-game-card-layout-unification-design.md
@@ -1,0 +1,121 @@
+# 마이페이지 위시리스트 탭 게임 카드 레이아웃 통일 Design
+
+**Date**: 2026-04-07
+**Status**: Ready
+**Branch**: `style/#296`
+**Issue**: #296
+
+---
+
+## Problem
+
+마이페이지 위시리스트 탭(`ProfileWishlistTab`)의 게임 목록 그리드 레이아웃이 게임 탐색 페이지(`/games`)의 `GameCardList` 컴포넌트와 달라 시각적 불일치가 발생함.
+
+| 위치 | 현재 레이아웃 | 최대 열 수 |
+|------|------------|-----------|
+| `ProfileWishlistTab` (위시리스트 탭) | `grid-cols-1 md:grid-cols-2` | 2열 |
+| `GameCardList` (게임 탐색 페이지) | `grid-cols-2 lg:grid-cols-5` | 5열 |
+
+같은 `GameCard` 컴포넌트를 사용하면서도 그리드 래퍼가 달라 동일한 게임 카드가 페이지마다 다르게 보임.
+
+---
+
+## Root Cause
+
+`ProfileWishlistTab.tsx`가 `GameCardList`를 재사용하지 않고 직접 `<div className="grid grid-cols-1 gap-6 md:grid-cols-2">` 래퍼를 수동으로 정의하여 `GameCard`를 반복 렌더링하고 있기 때문.
+
+```tsx
+// 현재 코드 (ProfileWishlistTab.tsx:42-46)
+<div className="grid grid-cols-1 gap-6 md:grid-cols-2">
+    {games.map((game) => (
+        <GameCard key={game.id} {...game} />
+    ))}
+</div>
+```
+
+---
+
+## Decisions
+
+| 질문 | 결정 | 근거 |
+|------|------|------|
+| `GameCardList`로 교체할 것인가 | 교체 | 그리드 레이아웃을 단일 출처(GameCardList)로 통일, 향후 레이아웃 변경 시 한 곳만 수정 |
+| 빈 상태 메시지를 `GameCardList`에 위임할 것인가 | 위임 안 함 | `GameCardList`의 빈 상태는 "검색 결과가 없습니다"(검색 특화 문구 + 이미지)이므로 위시리스트 컨텍스트에 부적합 |
+| `Pager`는 유지할 것인가 | 유지 | 위시리스트 전용 페이지네이션 기능은 `GameCardList` 범위 밖 |
+
+---
+
+## Architecture
+
+### 변경 전
+
+```
+ProfileWishlistTab
+  ├── 빈 상태: <p>위시리스트에 등록된 게임이 없습니다.</p>
+  └── 게임 있음:
+        ├── <div className="grid grid-cols-1 gap-6 md:grid-cols-2">
+        │     └── GameCard × N  (직접 렌더링)
+        └── Pager
+```
+
+### 변경 후
+
+```
+ProfileWishlistTab
+  ├── 빈 상태: <p>위시리스트에 등록된 게임이 없습니다.</p>  ← 유지
+  └── 게임 있음:
+        ├── GameCardList  ← grid-cols-2 lg:grid-cols-5 (재사용)
+        └── Pager         ← 유지
+```
+
+### 수정 코드
+
+```tsx
+// ProfileWishlistTab.tsx 변경 사항
+
+// Before
+import GameCard from "@/app/(base)/games/components/GameCard";
+// ...
+<div className="grid grid-cols-1 gap-6 md:grid-cols-2">
+    {games.map((game) => (
+        <GameCard key={game.id} {...game} />
+    ))}
+</div>
+
+// After
+import GameCardList from "@/app/(base)/games/components/GameCardList";
+// ...
+<GameCardList games={games} />
+```
+
+---
+
+## Testing
+
+### 신규 테스트: `ProfileWishlistTab.test.tsx`
+
+| 케이스 | 입력 | 기대 |
+|--------|------|------|
+| 빈 상태 메시지 | `games=[]` | "위시리스트에 등록된 게임이 없습니다." 노출 |
+| `GameCardList` 렌더링 | `games=[...]` | `GameCardList` 컴포넌트가 렌더링됨 |
+| 빈 상태 메시지 미노출 | `games=[...]` | 빈 상태 문구 미노출 |
+
+**TDD 순서**: `GameCardList` mock → `data-testid="game-card-list"` 확인 → 구현 전 RED → 구현 후 GREEN
+
+---
+
+## Out of Scope
+
+- `GameCardList.tsx` 자체 수정 (레이아웃 클래스 변경 없음)
+- `Pager` 동작 변경
+- API / 데이터 페칭 로직 변경
+- 위시리스트 탭 외 다른 탭 레이아웃 변경
+
+---
+
+## Affected Files
+
+| 파일 | 변경 |
+|------|------|
+| `app/(base)/profile/components/tabs/ProfileWishlistTab.tsx` | `GameCard` import 제거, `GameCardList` import 추가, 수동 grid div → `GameCardList` 교체 |
+| `app/(base)/profile/components/tabs/__tests__/ProfileWishlistTab.test.tsx` | 신규 생성 (3 test cases) |

--- a/package-lock.json
+++ b/package-lock.json
@@ -2082,20 +2082,10 @@
                 "node": ">=12.4.0"
             }
         },
-        "node_modules/@oxc-project/runtime": {
-            "version": "0.115.0",
-            "resolved": "https://registry.npmjs.org/@oxc-project/runtime/-/runtime-0.115.0.tgz",
-            "integrity": "sha512-Rg8Wlt5dCbXhQnsXPrkOjL1DTSvXLgb2R/KYfnf1/K+R0k6UMLEmbQXPM+kwrWqSmWA2t0B1EtHy2/3zikQpvQ==",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": "^20.19.0 || >=22.12.0"
-            }
-        },
         "node_modules/@oxc-project/types": {
-            "version": "0.115.0",
-            "resolved": "https://registry.npmjs.org/@oxc-project/types/-/types-0.115.0.tgz",
-            "integrity": "sha512-4n91DKnebUS4yjUHl2g3/b2T+IUdCfmoZGhmwsovZCDaJSs+QkVAM+0AqqTxHSsHfeiMuueT75cZaZcT/m0pSw==",
+            "version": "0.122.0",
+            "resolved": "https://registry.npmjs.org/@oxc-project/types/-/types-0.122.0.tgz",
+            "integrity": "sha512-oLAl5kBpV4w69UtFZ9xqcmTi+GENWOcPF7FCrczTiBbmC0ibXxCwyvZGbO39rCVEuLGAZM84DH0pUIyyv/YJzA==",
             "dev": true,
             "license": "MIT",
             "funding": {
@@ -2218,9 +2208,9 @@
             }
         },
         "node_modules/@rolldown/binding-android-arm64": {
-            "version": "1.0.0-rc.9",
-            "resolved": "https://registry.npmjs.org/@rolldown/binding-android-arm64/-/binding-android-arm64-1.0.0-rc.9.tgz",
-            "integrity": "sha512-lcJL0bN5hpgJfSIz/8PIf02irmyL43P+j1pTCfbD1DbLkmGRuFIA4DD3B3ZOvGqG0XiVvRznbKtN0COQVaKUTg==",
+            "version": "1.0.0-rc.12",
+            "resolved": "https://registry.npmjs.org/@rolldown/binding-android-arm64/-/binding-android-arm64-1.0.0-rc.12.tgz",
+            "integrity": "sha512-pv1y2Fv0JybcykuiiD3qBOBdz6RteYojRFY1d+b95WVuzx211CRh+ytI/+9iVyWQ6koTh5dawe4S/yRfOFjgaA==",
             "cpu": [
                 "arm64"
             ],
@@ -2235,9 +2225,9 @@
             }
         },
         "node_modules/@rolldown/binding-darwin-arm64": {
-            "version": "1.0.0-rc.9",
-            "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-arm64/-/binding-darwin-arm64-1.0.0-rc.9.tgz",
-            "integrity": "sha512-J7Zk3kLYFsLtuH6U+F4pS2sYVzac0qkjcO5QxHS7OS7yZu2LRs+IXo+uvJ/mvpyUljDJ3LROZPoQfgBIpCMhdQ==",
+            "version": "1.0.0-rc.12",
+            "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-arm64/-/binding-darwin-arm64-1.0.0-rc.12.tgz",
+            "integrity": "sha512-cFYr6zTG/3PXXF3pUO+umXxt1wkRK/0AYT8lDwuqvRC+LuKYWSAQAQZjCWDQpAH172ZV6ieYrNnFzVVcnSflAg==",
             "cpu": [
                 "arm64"
             ],
@@ -2252,9 +2242,9 @@
             }
         },
         "node_modules/@rolldown/binding-darwin-x64": {
-            "version": "1.0.0-rc.9",
-            "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-x64/-/binding-darwin-x64-1.0.0-rc.9.tgz",
-            "integrity": "sha512-iwtmmghy8nhfRGeNAIltcNXzD0QMNaaA5U/NyZc1Ia4bxrzFByNMDoppoC+hl7cDiUq5/1CnFthpT9n+UtfFyg==",
+            "version": "1.0.0-rc.12",
+            "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-x64/-/binding-darwin-x64-1.0.0-rc.12.tgz",
+            "integrity": "sha512-ZCsYknnHzeXYps0lGBz8JrF37GpE9bFVefrlmDrAQhOEi4IOIlcoU1+FwHEtyXGx2VkYAvhu7dyBf75EJQffBw==",
             "cpu": [
                 "x64"
             ],
@@ -2269,9 +2259,9 @@
             }
         },
         "node_modules/@rolldown/binding-freebsd-x64": {
-            "version": "1.0.0-rc.9",
-            "resolved": "https://registry.npmjs.org/@rolldown/binding-freebsd-x64/-/binding-freebsd-x64-1.0.0-rc.9.tgz",
-            "integrity": "sha512-DLFYI78SCiZr5VvdEplsVC2Vx53lnA4/Ga5C65iyldMVaErr86aiqCoNBLl92PXPfDtUYjUh+xFFor40ueNs4Q==",
+            "version": "1.0.0-rc.12",
+            "resolved": "https://registry.npmjs.org/@rolldown/binding-freebsd-x64/-/binding-freebsd-x64-1.0.0-rc.12.tgz",
+            "integrity": "sha512-dMLeprcVsyJsKolRXyoTH3NL6qtsT0Y2xeuEA8WQJquWFXkEC4bcu1rLZZSnZRMtAqwtrF/Ib9Ddtpa/Gkge9Q==",
             "cpu": [
                 "x64"
             ],
@@ -2286,9 +2276,9 @@
             }
         },
         "node_modules/@rolldown/binding-linux-arm-gnueabihf": {
-            "version": "1.0.0-rc.9",
-            "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-1.0.0-rc.9.tgz",
-            "integrity": "sha512-CsjTmTwd0Hri6iTw/DRMK7kOZ7FwAkrO4h8YWKoX/kcj833e4coqo2wzIFywtch/8Eb5enQ/lwLM7w6JX1W5RQ==",
+            "version": "1.0.0-rc.12",
+            "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-1.0.0-rc.12.tgz",
+            "integrity": "sha512-YqWjAgGC/9M1lz3GR1r1rP79nMgo3mQiiA+Hfo+pvKFK1fAJ1bCi0ZQVh8noOqNacuY1qIcfyVfP6HoyBRZ85Q==",
             "cpu": [
                 "arm"
             ],
@@ -2303,9 +2293,9 @@
             }
         },
         "node_modules/@rolldown/binding-linux-arm64-gnu": {
-            "version": "1.0.0-rc.9",
-            "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-1.0.0-rc.9.tgz",
-            "integrity": "sha512-2x9O2JbSPxpxMDhP9Z74mahAStibTlrBMW0520+epJH5sac7/LwZW5Bmg/E6CXuEF53JJFW509uP+lSedaUNxg==",
+            "version": "1.0.0-rc.12",
+            "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-1.0.0-rc.12.tgz",
+            "integrity": "sha512-/I5AS4cIroLpslsmzXfwbe5OmWvSsrFuEw3mwvbQ1kDxJ822hFHIx+vsN/TAzNVyepI/j/GSzrtCIwQPeKCLIg==",
             "cpu": [
                 "arm64"
             ],
@@ -2320,9 +2310,9 @@
             }
         },
         "node_modules/@rolldown/binding-linux-arm64-musl": {
-            "version": "1.0.0-rc.9",
-            "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-musl/-/binding-linux-arm64-musl-1.0.0-rc.9.tgz",
-            "integrity": "sha512-JA1QRW31ogheAIRhIg9tjMfsYbglXXYGNPLdPEYrwFxdbkQCAzvpSCSHCDWNl4hTtrol8WeboCSEpjdZK8qrCg==",
+            "version": "1.0.0-rc.12",
+            "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-musl/-/binding-linux-arm64-musl-1.0.0-rc.12.tgz",
+            "integrity": "sha512-V6/wZztnBqlx5hJQqNWwFdxIKN0m38p8Jas+VoSfgH54HSj9tKTt1dZvG6JRHcjh6D7TvrJPWFGaY9UBVOaWPw==",
             "cpu": [
                 "arm64"
             ],
@@ -2337,9 +2327,9 @@
             }
         },
         "node_modules/@rolldown/binding-linux-ppc64-gnu": {
-            "version": "1.0.0-rc.9",
-            "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-1.0.0-rc.9.tgz",
-            "integrity": "sha512-aOKU9dJheda8Kj8Y3w9gnt9QFOO+qKPAl8SWd7JPHP+Cu0EuDAE5wokQubLzIDQWg2myXq2XhTpOVS07qqvT+w==",
+            "version": "1.0.0-rc.12",
+            "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-1.0.0-rc.12.tgz",
+            "integrity": "sha512-AP3E9BpcUYliZCxa3w5Kwj9OtEVDYK6sVoUzy4vTOJsjPOgdaJZKFmN4oOlX0Wp0RPV2ETfmIra9x1xuayFB7g==",
             "cpu": [
                 "ppc64"
             ],
@@ -2354,9 +2344,9 @@
             }
         },
         "node_modules/@rolldown/binding-linux-s390x-gnu": {
-            "version": "1.0.0-rc.9",
-            "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-1.0.0-rc.9.tgz",
-            "integrity": "sha512-OalO94fqj7IWRn3VdXWty75jC5dk4C197AWEuMhIpvVv2lw9fiPhud0+bW2ctCxb3YoBZor71QHbY+9/WToadA==",
+            "version": "1.0.0-rc.12",
+            "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-1.0.0-rc.12.tgz",
+            "integrity": "sha512-nWwpvUSPkoFmZo0kQazZYOrT7J5DGOJ/+QHHzjvNlooDZED8oH82Yg67HvehPPLAg5fUff7TfWFHQS8IV1n3og==",
             "cpu": [
                 "s390x"
             ],
@@ -2371,9 +2361,9 @@
             }
         },
         "node_modules/@rolldown/binding-linux-x64-gnu": {
-            "version": "1.0.0-rc.9",
-            "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-gnu/-/binding-linux-x64-gnu-1.0.0-rc.9.tgz",
-            "integrity": "sha512-cVEl1vZtBsBZna3YMjGXNvnYYrOJ7RzuWvZU0ffvJUexWkukMaDuGhUXn0rjnV0ptzGVkvc+vW9Yqy6h8YX4pg==",
+            "version": "1.0.0-rc.12",
+            "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-gnu/-/binding-linux-x64-gnu-1.0.0-rc.12.tgz",
+            "integrity": "sha512-RNrafz5bcwRy+O9e6P8Z/OCAJW/A+qtBczIqVYwTs14pf4iV1/+eKEjdOUta93q2TsT/FI0XYDP3TCky38LMAg==",
             "cpu": [
                 "x64"
             ],
@@ -2388,9 +2378,9 @@
             }
         },
         "node_modules/@rolldown/binding-linux-x64-musl": {
-            "version": "1.0.0-rc.9",
-            "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-musl/-/binding-linux-x64-musl-1.0.0-rc.9.tgz",
-            "integrity": "sha512-UzYnKCIIc4heAKgI4PZ3dfBGUZefGCJ1TPDuLHoCzgrMYPb5Rv6TLFuYtyM4rWyHM7hymNdsg5ik2C+UD9VDbA==",
+            "version": "1.0.0-rc.12",
+            "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-musl/-/binding-linux-x64-musl-1.0.0-rc.12.tgz",
+            "integrity": "sha512-Jpw/0iwoKWx3LJ2rc1yjFrj+T7iHZn2JDg1Yny1ma0luviFS4mhAIcd1LFNxK3EYu3DHWCps0ydXQ5i/rrJ2ig==",
             "cpu": [
                 "x64"
             ],
@@ -2405,9 +2395,9 @@
             }
         },
         "node_modules/@rolldown/binding-openharmony-arm64": {
-            "version": "1.0.0-rc.9",
-            "resolved": "https://registry.npmjs.org/@rolldown/binding-openharmony-arm64/-/binding-openharmony-arm64-1.0.0-rc.9.tgz",
-            "integrity": "sha512-+6zoiF+RRyf5cdlFQP7nm58mq7+/2PFaY2DNQeD4B87N36JzfF/l9mdBkkmTvSYcYPE8tMh/o3cRlsx1ldLfog==",
+            "version": "1.0.0-rc.12",
+            "resolved": "https://registry.npmjs.org/@rolldown/binding-openharmony-arm64/-/binding-openharmony-arm64-1.0.0-rc.12.tgz",
+            "integrity": "sha512-vRugONE4yMfVn0+7lUKdKvN4D5YusEiPilaoO2sgUWpCvrncvWgPMzK00ZFFJuiPgLwgFNP5eSiUlv2tfc+lpA==",
             "cpu": [
                 "arm64"
             ],
@@ -2422,9 +2412,9 @@
             }
         },
         "node_modules/@rolldown/binding-wasm32-wasi": {
-            "version": "1.0.0-rc.9",
-            "resolved": "https://registry.npmjs.org/@rolldown/binding-wasm32-wasi/-/binding-wasm32-wasi-1.0.0-rc.9.tgz",
-            "integrity": "sha512-rgFN6sA/dyebil3YTlL2evvi/M+ivhfnyxec7AccTpRPccno/rPoNlqybEZQBkcbZu8Hy+eqNJCqfBR8P7Pg8g==",
+            "version": "1.0.0-rc.12",
+            "resolved": "https://registry.npmjs.org/@rolldown/binding-wasm32-wasi/-/binding-wasm32-wasi-1.0.0-rc.12.tgz",
+            "integrity": "sha512-ykGiLr/6kkiHc0XnBfmFJuCjr5ZYKKofkx+chJWDjitX+KsJuAmrzWhwyOMSHzPhzOHOy7u9HlFoa5MoAOJ/Zg==",
             "cpu": [
                 "wasm32"
             ],
@@ -2439,20 +2429,22 @@
             }
         },
         "node_modules/@rolldown/binding-wasm32-wasi/node_modules/@napi-rs/wasm-runtime": {
-            "version": "1.1.1",
-            "resolved": "https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-1.1.1.tgz",
-            "integrity": "sha512-p64ah1M1ld8xjWv3qbvFwHiFVWrq1yFvV4f7w+mzaqiR4IlSgkqhcRdHwsGgomwzBH51sRY4NEowLxnaBjcW/A==",
+            "version": "1.1.2",
+            "resolved": "https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-1.1.2.tgz",
+            "integrity": "sha512-sNXv5oLJ7ob93xkZ1XnxisYhGYXfaG9f65/ZgYuAu3qt7b3NadcOEhLvx28hv31PgX8SZJRYrAIPQilQmFpLVw==",
             "dev": true,
             "license": "MIT",
             "optional": true,
             "dependencies": {
-                "@emnapi/core": "^1.7.1",
-                "@emnapi/runtime": "^1.7.1",
                 "@tybys/wasm-util": "^0.10.1"
             },
             "funding": {
                 "type": "github",
                 "url": "https://github.com/sponsors/Brooooooklyn"
+            },
+            "peerDependencies": {
+                "@emnapi/core": "^1.7.1",
+                "@emnapi/runtime": "^1.7.1"
             }
         },
         "node_modules/@rolldown/binding-wasm32-wasi/node_modules/@tybys/wasm-util": {
@@ -2467,9 +2459,9 @@
             }
         },
         "node_modules/@rolldown/binding-win32-arm64-msvc": {
-            "version": "1.0.0-rc.9",
-            "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-1.0.0-rc.9.tgz",
-            "integrity": "sha512-lHVNUG/8nlF1IQk1C0Ci574qKYyty2goMiPlRqkC5R+3LkXDkL5Dhx8ytbxq35m+pkHVIvIxviD+TWLdfeuadA==",
+            "version": "1.0.0-rc.12",
+            "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-1.0.0-rc.12.tgz",
+            "integrity": "sha512-5eOND4duWkwx1AzCxadcOrNeighiLwMInEADT0YM7xeEOOFcovWZCq8dadXgcRHSf3Ulh1kFo/qvzoFiCLOL1Q==",
             "cpu": [
                 "arm64"
             ],
@@ -2484,9 +2476,9 @@
             }
         },
         "node_modules/@rolldown/binding-win32-x64-msvc": {
-            "version": "1.0.0-rc.9",
-            "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-x64-msvc/-/binding-win32-x64-msvc-1.0.0-rc.9.tgz",
-            "integrity": "sha512-G0oA4+w1iY5AGi5HcDTxWsoxF509hrFIPB2rduV5aDqS9FtDg1CAfa7V34qImbjfhIcA8C+RekocJZA96EarwQ==",
+            "version": "1.0.0-rc.12",
+            "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-x64-msvc/-/binding-win32-x64-msvc-1.0.0-rc.12.tgz",
+            "integrity": "sha512-PyqoipaswDLAZtot351MLhrlrh6lcZPo2LSYE+VDxbVk24LVKAGOuE4hb8xZQmrPAuEtTZW8E6D2zc5EUZX4Lw==",
             "cpu": [
                 "x64"
             ],
@@ -8828,14 +8820,14 @@
             }
         },
         "node_modules/rolldown": {
-            "version": "1.0.0-rc.9",
-            "resolved": "https://registry.npmjs.org/rolldown/-/rolldown-1.0.0-rc.9.tgz",
-            "integrity": "sha512-9EbgWge7ZH+yqb4d2EnELAntgPTWbfL8ajiTW+SyhJEC4qhBbkCKbqFV4Ge4zmu5ziQuVbWxb/XwLZ+RIO7E8Q==",
+            "version": "1.0.0-rc.12",
+            "resolved": "https://registry.npmjs.org/rolldown/-/rolldown-1.0.0-rc.12.tgz",
+            "integrity": "sha512-yP4USLIMYrwpPHEFB5JGH1uxhcslv6/hL0OyvTuY+3qlOSJvZ7ntYnoWpehBxufkgN0cvXxppuTu5hHa/zPh+A==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@oxc-project/types": "=0.115.0",
-                "@rolldown/pluginutils": "1.0.0-rc.9"
+                "@oxc-project/types": "=0.122.0",
+                "@rolldown/pluginutils": "1.0.0-rc.12"
             },
             "bin": {
                 "rolldown": "bin/cli.mjs"
@@ -8844,27 +8836,27 @@
                 "node": "^20.19.0 || >=22.12.0"
             },
             "optionalDependencies": {
-                "@rolldown/binding-android-arm64": "1.0.0-rc.9",
-                "@rolldown/binding-darwin-arm64": "1.0.0-rc.9",
-                "@rolldown/binding-darwin-x64": "1.0.0-rc.9",
-                "@rolldown/binding-freebsd-x64": "1.0.0-rc.9",
-                "@rolldown/binding-linux-arm-gnueabihf": "1.0.0-rc.9",
-                "@rolldown/binding-linux-arm64-gnu": "1.0.0-rc.9",
-                "@rolldown/binding-linux-arm64-musl": "1.0.0-rc.9",
-                "@rolldown/binding-linux-ppc64-gnu": "1.0.0-rc.9",
-                "@rolldown/binding-linux-s390x-gnu": "1.0.0-rc.9",
-                "@rolldown/binding-linux-x64-gnu": "1.0.0-rc.9",
-                "@rolldown/binding-linux-x64-musl": "1.0.0-rc.9",
-                "@rolldown/binding-openharmony-arm64": "1.0.0-rc.9",
-                "@rolldown/binding-wasm32-wasi": "1.0.0-rc.9",
-                "@rolldown/binding-win32-arm64-msvc": "1.0.0-rc.9",
-                "@rolldown/binding-win32-x64-msvc": "1.0.0-rc.9"
+                "@rolldown/binding-android-arm64": "1.0.0-rc.12",
+                "@rolldown/binding-darwin-arm64": "1.0.0-rc.12",
+                "@rolldown/binding-darwin-x64": "1.0.0-rc.12",
+                "@rolldown/binding-freebsd-x64": "1.0.0-rc.12",
+                "@rolldown/binding-linux-arm-gnueabihf": "1.0.0-rc.12",
+                "@rolldown/binding-linux-arm64-gnu": "1.0.0-rc.12",
+                "@rolldown/binding-linux-arm64-musl": "1.0.0-rc.12",
+                "@rolldown/binding-linux-ppc64-gnu": "1.0.0-rc.12",
+                "@rolldown/binding-linux-s390x-gnu": "1.0.0-rc.12",
+                "@rolldown/binding-linux-x64-gnu": "1.0.0-rc.12",
+                "@rolldown/binding-linux-x64-musl": "1.0.0-rc.12",
+                "@rolldown/binding-openharmony-arm64": "1.0.0-rc.12",
+                "@rolldown/binding-wasm32-wasi": "1.0.0-rc.12",
+                "@rolldown/binding-win32-arm64-msvc": "1.0.0-rc.12",
+                "@rolldown/binding-win32-x64-msvc": "1.0.0-rc.12"
             }
         },
         "node_modules/rolldown/node_modules/@rolldown/pluginutils": {
-            "version": "1.0.0-rc.9",
-            "resolved": "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.0-rc.9.tgz",
-            "integrity": "sha512-w6oiRWgEBl04QkFZgmW+jnU1EC9b57Oihi2ot3HNWIQRqgHp5PnYDia5iZ5FF7rpa4EQdiqMDXjlqKGXBhsoXw==",
+            "version": "1.0.0-rc.12",
+            "resolved": "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.0-rc.12.tgz",
+            "integrity": "sha512-HHMwmarRKvoFsJorqYlFeFRzXZqCt2ETQlEDOb9aqssrnVBB1/+xgTGtuTrIk5vzLNX1MjMtTf7W9z3tsSbrxw==",
             "dev": true,
             "license": "MIT"
         },
@@ -10214,17 +10206,16 @@
             }
         },
         "node_modules/vite": {
-            "version": "8.0.0",
-            "resolved": "https://registry.npmjs.org/vite/-/vite-8.0.0.tgz",
-            "integrity": "sha512-fPGaRNj9Zytaf8LEiBhY7Z6ijnFKdzU/+mL8EFBaKr7Vw1/FWcTBAMW0wLPJAGMPX38ZPVCVgLceWiEqeoqL2Q==",
+            "version": "8.0.5",
+            "resolved": "https://registry.npmjs.org/vite/-/vite-8.0.5.tgz",
+            "integrity": "sha512-nmu43Qvq9UopTRfMx2jOYW5l16pb3iDC1JH6yMuPkpVbzK0k+L7dfsEDH4jRgYFmsg0sTAqkojoZgzLMlwHsCQ==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@oxc-project/runtime": "0.115.0",
                 "lightningcss": "^1.32.0",
-                "picomatch": "^4.0.3",
+                "picomatch": "^4.0.4",
                 "postcss": "^8.5.8",
-                "rolldown": "1.0.0-rc.9",
+                "rolldown": "1.0.0-rc.12",
                 "tinyglobby": "^0.2.15"
             },
             "bin": {
@@ -10241,8 +10232,8 @@
             },
             "peerDependencies": {
                 "@types/node": "^20.19.0 || >=22.12.0",
-                "@vitejs/devtools": "^0.0.0-alpha.31",
-                "esbuild": "^0.27.0",
+                "@vitejs/devtools": "^0.1.0",
+                "esbuild": "^0.27.0 || ^0.28.0",
                 "jiti": ">=1.21.0",
                 "less": "^4.0.0",
                 "sass": "^1.70.0",


### PR DESCRIPTION
## ✨ 작업 개요

마이페이지 위시리스트 탭(`ProfileWishlistTab`)의 게임 목록 그리드 레이아웃을 게임 탐색 페이지(`/games`)의 `GameCardList` 컴포넌트로 통일합니다.

## ✅ 상세 내용

- [x] `ProfileWishlistTab.tsx`에서 수동 `grid-cols-1 md:grid-cols-2` 레이아웃 + `GameCard` 직접 반복 렌더링 제거
- [x] `GameCardList` 컴포넌트로 교체하여 `grid-cols-2 lg:grid-cols-5` 레이아웃 통일
- [x] 빈 상태 메시지("위시리스트에 등록된 게임이 없습니다.")는 위시리스트 고유 메시지 유지 (`GameCardList`의 검색 특화 빈 상태와 분리)
- [x] `ProfileWishlistTab.test.tsx` 신규 생성 — 5개 테스트 케이스 (빈 상태, GameCardList 렌더링, Pager 조건부 렌더링)

## 📸 스크린샷 (선택)

<img width="1585" height="911" alt="image" src="https://github.com/user-attachments/assets/121612c3-3e09-44ea-876c-26f7b45ff712" />

## 🧪 확인 사항

- [x] 정상적으로 동작하는지 직접 테스트해봤나요? — 전체 321개 테스트 통과, 프로덕션 빌드 성공
- [x] 기능 추가/수정 후 UI나 비즈니스 로직에 영향은 없나요? — 레이아웃 변경만, 데이터/로직 영향 없음
- [x] PR 리뷰어가 중점적으로 확인하면 좋을 부분은? — `ProfileWishlistTab`에서 `GameCardList`로 빈 배열이 전달되지 않도록 부모에서 먼저 빈 상태 분기하는 구조

## 🙏 기타 참고 사항

- `GameCardList`의 빈 상태 UI("검색 결과가 없습니다" + 이미지)는 검색 컨텍스트에 특화되어 있어 위시리스트에 부적합 → 부모 컴포넌트에서 직접 처리

## 이슈 관리

close #296