### PR TITLE
[fix/#301] 도전장 작성하기 모달 미표시 수정

### DIFF
--- a/app/(base)/arenas/components/CreateArenaModal.tsx
+++ b/app/(base)/arenas/components/CreateArenaModal.tsx
@@ -78,11 +78,6 @@ export default function CreateArenaModal() {
                     errorData.message || "투기장 생성에 실패했습니다."
                 );
             }
-
-            await fetch("/api/member/scores", {
-                method: "POST",
-                body: JSON.stringify({ policyId: 4, actualScore: -100 }),
-            });
         },
         onSuccess: () => {
             closeModal();

--- a/app/api/member/arenas/__tests__/route.test.ts
+++ b/app/api/member/arenas/__tests__/route.test.ts
@@ -11,6 +11,18 @@ vi.mock(
             this.findById = vi
                 .fn()
                 .mockResolvedValue({ id: "test-user-id", score: 200 });
+            this.incrementScore = vi.fn().mockResolvedValue(undefined);
+        }),
+    })
+);
+
+vi.mock(
+    "@/backend/score-record/infra/repositories/prisma/PrismaScoreRecordRepository",
+    () => ({
+        PrismaScoreRecordRepository: vi.fn(function (
+            this: Record<string, unknown>
+        ) {
+            this.createRecord = vi.fn().mockResolvedValue(undefined);
         }),
     })
 );

--- a/app/api/member/arenas/__tests__/route.test.ts
+++ b/app/api/member/arenas/__tests__/route.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi } from "vitest";
+import { describe, it, expect, vi, beforeEach } from "vitest";
 
 vi.mock("@/utils/GetAuthUserId.server", () => ({
     getAuthUserId: vi.fn().mockResolvedValue("test-user-id"),
@@ -49,8 +49,13 @@ vi.mock("@/backend/arena/application/usecase/CreateArenaUsecase", () => ({
 }));
 
 import { POST } from "../route";
+import { PrismaMemberRepository } from "@/backend/member/infra/repositories/prisma/PrismaMemberRepository";
+import { PrismaScoreRecordRepository } from "@/backend/score-record/infra/repositories/prisma/PrismaScoreRecordRepository";
 
 describe("POST /api/member/arenas", () => {
+    beforeEach(() => {
+        vi.clearAllMocks();
+    });
     it("POST without auth session returns 401", async () => {
         const { getAuthUserId } = await import("@/utils/GetAuthUserId.server");
         vi.mocked(getAuthUserId).mockResolvedValueOnce(null);
@@ -80,5 +85,38 @@ describe("POST /api/member/arenas", () => {
         });
         const response = await POST(req);
         expect(response.status).toBe(201);
+    });
+
+    it("POST calls incrementScore(-100) and createRecord with policyId 4", async () => {
+        const req = new Request("http://localhost/api/member/arenas", {
+            method: "POST",
+            body: JSON.stringify({
+                title: "Test Arena",
+                description: "Some description",
+                startDate: "2026-04-01T00:00:00.000Z",
+            }),
+            headers: { "content-type": "application/json" },
+        });
+
+        await POST(req);
+
+        const memberInst = vi
+            .mocked(PrismaMemberRepository)
+            .mock.instances.at(-1) as unknown as {
+            incrementScore: ReturnType<typeof vi.fn>;
+        };
+        expect(memberInst.incrementScore).toHaveBeenCalledWith(
+            "test-user-id",
+            -100
+        );
+
+        const scoreInst = vi
+            .mocked(PrismaScoreRecordRepository)
+            .mock.instances.at(-1) as unknown as {
+            createRecord: ReturnType<typeof vi.fn>;
+        };
+        expect(scoreInst.createRecord).toHaveBeenCalledWith(
+            expect.objectContaining({ policyId: 4, actualScore: -100 })
+        );
     });
 });

--- a/app/api/member/arenas/route.ts
+++ b/app/api/member/arenas/route.ts
@@ -62,6 +62,9 @@ export async function POST(request: Request) {
         const newArena: Arena =
             await createArenaUsecase.execute(createArenaDto);
 
+        // TODO: 아레나 생성·점수 차감·기록 생성을 prisma.$transaction으로 묶어 원자성 보장 필요
+        // 현재는 순차 실행이므로 중간 단계 실패 시 데이터 불일치가 발생할 수 있음
+        // ref: https://github.com/FRONT-END-BOOTCAMP-PLUS-4/gamechu/issues/307
         await memberRepository.incrementScore(memberId, -100);
 
         const scoreRecordRepository = new PrismaScoreRecordRepository();

--- a/app/api/member/arenas/route.ts
+++ b/app/api/member/arenas/route.ts
@@ -1,16 +1,10 @@
-import { CreateArenaUsecase } from "@/backend/arena/application/usecase/CreateArenaUsecase";
-import { CreateArenaDto } from "@/backend/arena/application/usecase/dto/CreateArenaDto";
 import { CreateArenaSchema } from "@/backend/arena/application/usecase/dto/CreateArenaDto";
-import { ArenaRepository } from "@/backend/arena/domain/repositories/ArenaRepository";
-import { PrismaArenaRepository } from "@/backend/arena/infra/repositories/prisma/PrismaArenaRepository";
 import { PrismaMemberRepository } from "@/backend/member/infra/repositories/prisma/PrismaMemberRepository";
-import { PrismaScoreRecordRepository } from "@/backend/score-record/infra/repositories/prisma/PrismaScoreRecordRepository";
-import { CreateScoreRecordDto } from "@/backend/score-record/application/usecase/dto/CreateScoreRecordDto";
-import { Arena } from "@/prisma/generated";
 import { getAuthUserId } from "@/utils/GetAuthUserId.server";
 import { validate } from "@/utils/Validation";
 import { NextResponse } from "next/server";
 import logger from "@/lib/Logger";
+import { prisma } from "@/lib/Prisma";
 
 export async function POST(request: Request) {
     const memberId: string | null = await getAuthUserId();
@@ -48,29 +42,27 @@ export async function POST(request: Request) {
             );
         }
 
-        // execute usecase
-        const createArenaDto: CreateArenaDto = new CreateArenaDto(
-            memberId,
-            validated.data.title,
-            validated.data.description,
-            new Date(validated.data.startDate)
-        );
-        const arenaRepository: ArenaRepository = new PrismaArenaRepository();
-        const createArenaUsecase: CreateArenaUsecase = new CreateArenaUsecase(
-            arenaRepository
-        );
-        const newArena: Arena =
-            await createArenaUsecase.execute(createArenaDto);
-
-        // TODO: 아레나 생성·점수 차감·기록 생성을 prisma.$transaction으로 묶어 원자성 보장 필요
-        // 현재는 순차 실행이므로 중간 단계 실패 시 데이터 불일치가 발생할 수 있음
-        // ref: https://github.com/FRONT-END-BOOTCAMP-PLUS-4/gamechu/issues/307
-        await memberRepository.incrementScore(memberId, -100);
-
-        const scoreRecordRepository = new PrismaScoreRecordRepository();
-        await scoreRecordRepository.createRecord(
-            new CreateScoreRecordDto(memberId, 4, -100)
-        );
+        // 아레나 생성·점수 차감·기록 생성을 트랜잭션으로 원자적으로 처리
+        const newArena = await prisma.$transaction(async (tx) => {
+            const arena = await tx.arena.create({
+                data: {
+                    creatorId: memberId,
+                    challengerId: null,
+                    title: validated.data.title,
+                    description: validated.data.description,
+                    status: 1,
+                    startDate: new Date(validated.data.startDate),
+                },
+            });
+            await tx.member.update({
+                where: { id: memberId },
+                data: { score: { decrement: 100 } },
+            });
+            await tx.scoreRecord.create({
+                data: { memberId, policyId: 4, actualScore: -100 },
+            });
+            return arena;
+        });
 
         return NextResponse.json(newArena, { status: 201 });
     } catch (error: unknown) {

--- a/app/api/member/arenas/route.ts
+++ b/app/api/member/arenas/route.ts
@@ -4,6 +4,8 @@ import { CreateArenaSchema } from "@/backend/arena/application/usecase/dto/Creat
 import { ArenaRepository } from "@/backend/arena/domain/repositories/ArenaRepository";
 import { PrismaArenaRepository } from "@/backend/arena/infra/repositories/prisma/PrismaArenaRepository";
 import { PrismaMemberRepository } from "@/backend/member/infra/repositories/prisma/PrismaMemberRepository";
+import { PrismaScoreRecordRepository } from "@/backend/score-record/infra/repositories/prisma/PrismaScoreRecordRepository";
+import { CreateScoreRecordDto } from "@/backend/score-record/application/usecase/dto/CreateScoreRecordDto";
 import { Arena } from "@/prisma/generated";
 import { getAuthUserId } from "@/utils/GetAuthUserId.server";
 import { validate } from "@/utils/Validation";
@@ -59,6 +61,13 @@ export async function POST(request: Request) {
         );
         const newArena: Arena =
             await createArenaUsecase.execute(createArenaDto);
+
+        await memberRepository.incrementScore(memberId, -100);
+
+        const scoreRecordRepository = new PrismaScoreRecordRepository();
+        await scoreRecordRepository.createRecord(
+            new CreateScoreRecordDto(memberId, 4, -100)
+        );
 
         return NextResponse.json(newArena, { status: 201 });
     } catch (error: unknown) {

--- a/app/components/LottieLoader.tsx
+++ b/app/components/LottieLoader.tsx
@@ -8,7 +8,7 @@ export default function LottieLoader() {
     if (!loading) return null;
 
     return (
-        <div className="fixed inset-0 z-[9999] flex items-center justify-center">
+        <div className="fixed inset-0 z-[9999] flex items-center justify-center pointer-events-none">
             <div className="absolute inset-0 bg-background-400 opacity-50" />
 
             <div className="relative z-10">

--- a/app/components/LottieLoader.tsx
+++ b/app/components/LottieLoader.tsx
@@ -8,6 +8,7 @@ export default function LottieLoader() {
     if (!loading) return null;
 
     return (
+        // pointer-events-none: 로딩 중에도 모달 등 하단 UI와 상호작용 가능하도록 의도적으로 허용
         <div className="fixed inset-0 z-[9999] flex items-center justify-center pointer-events-none">
             <div className="absolute inset-0 bg-background-400 opacity-50" />
 

--- a/app/components/ModalWrapper.tsx
+++ b/app/components/ModalWrapper.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { ReactNode } from "react";
+import { ReactNode, useEffect } from "react";
 import { createPortal } from "react-dom";
 import FocusTrap from "focus-trap-react";
 
@@ -17,20 +17,28 @@ export default function ModalWrapper({
     children,
     labelId,
 }: ModalWrapperProps) {
+    useEffect(() => {
+        if (!isOpen) return;
+        const handleKeyDown = (e: KeyboardEvent) => {
+            if (e.key === "Escape") onClose();
+        };
+        document.addEventListener("keydown", handleKeyDown);
+        return () => document.removeEventListener("keydown", handleKeyDown);
+    }, [isOpen, onClose]);
+
     if (!isOpen) return null;
 
     return createPortal(
         <div
-            className="fixed inset-0 z-50 flex items-center justify-center bg-black/50 px-2 sm:px-4"
+            className="fixed inset-0 z-[10001] flex items-center justify-center bg-black/50 px-2 sm:px-4"
             onClick={onClose}
         >
             <FocusTrap
                 active={isOpen}
                 focusTrapOptions={{
-                    onDeactivate: onClose,
-                    returnFocusOnDeactivate: true,
-                    escapeDeactivates: true,
+                    escapeDeactivates: false,
                     allowOutsideClick: true,
+                    returnFocusOnDeactivate: true,
                 }}
             >
                 <div

--- a/app/components/ModalWrapper.tsx
+++ b/app/components/ModalWrapper.tsx
@@ -30,7 +30,7 @@ export default function ModalWrapper({
 
     return createPortal(
         <div
-            className="fixed inset-0 z-[10001] flex items-center justify-center bg-black/50 px-2 sm:px-4"
+            className="fixed inset-0 z-[10001] flex items-center justify-center bg-black/50 px-2 sm:px-4" // z-[10001]: LottieLoader(z-[9999]) 위에 표시되도록
             onClick={onClose}
         >
             <FocusTrap

--- a/docs/ecc/plans/arena-modal-bug-fix.md
+++ b/docs/ecc/plans/arena-modal-bug-fix.md
@@ -1,0 +1,102 @@
+# Arena Modal Bug Fix — 의사결정 기록
+
+도전장 작성하기 모달 미표시 버그 수정 과정에서 내린 주요 결정들을 기록합니다.
+
+이슈: #301 | PR: #303
+
+---
+
+## 1. 버그 원인 분석
+
+두 가지 독립적인 원인이 복합적으로 작용했습니다.
+
+**주 원인 — React 19 StrictMode + focus-trap-react**
+
+React 19 StrictMode에서 effects가 mount → unmount → mount 순서로 두 번 실행됩니다. `focus-trap-react`의 `onDeactivate: onClose` 설정이 cleanup(첫 번째 unmount) 시 즉시 `onClose`를 호출하여 모달을 닫아버림.
+
+**보조 원인 — LottieLoader 이벤트 차단**
+
+`LottieLoader`에 `pointer-events-none`이 없어 로딩 오버레이가 "도전장 작성하기" 버튼 클릭 이벤트를 차단했음. 로딩이 끝난 후에도 오버레이가 z-index 우위를 점하는 타이밍에 클릭이 발생하면 버튼 이벤트가 전달되지 않음.
+
+---
+
+## 2. FocusTrap 수정 방향 결정
+
+### 고려한 옵션
+
+**옵션 A — `checkCanDeactivate` 게이팅**
+
+`checkCanDeactivate` 콜백에서 실제 포커스 해제 요청인지 판별해 `onDeactivate` 호출을 차단.
+
+- 단점: 판별 로직이 복잡하고, React StrictMode의 cleanup을 "실제 비활성화"와 구분하는 신뢰할 만한 방법이 없음. 라이브러리 내부 동작에 의존하는 취약한 접근.
+
+**옵션 B — `onDeactivate` 제거 + ESC 직접 처리 (채택)**
+
+`onDeactivate`를 제거하고, ESC 키 처리를 `useEffect` 내 `keydown` 리스너로 직접 구현.
+
+- 장점: StrictMode cleanup과 무관하게 동작. ESC 처리 로직의 소유권이 컴포넌트 안에 있어 의도가 명확함.
+- 단점: `onClose`가 `useEffect` deps에 포함되므로, 부모가 `useCallback` 없이 인라인 함수를 전달하면 모달 열린 상태에서 매 렌더마다 리스너가 탈부착됨(기능적 버그는 아님, ECC 리뷰에서 지적).
+
+**결정 이유**: 옵션 A는 라이브러리 내부 구현에 의존하는 불안정한 패턴. 옵션 B는 동작 범위가 명확하고 StrictMode와 무관하게 예측 가능.
+
+---
+
+## 3. z-index z-50 → z-[10001] 변경
+
+`LottieLoader`의 z-index가 `z-9999`(= 9999)이므로, 모달이 로딩 오버레이 위에 표시되려면 그보다 높은 값이 필요했습니다. `z-[10001]`은 Tailwind 임의값 문법으로 10001을 명시한 것이며, 이 수치가 LottieLoader(`z-9999`)와의 관계를 의식한 값임을 주석으로 기록했습니다.
+
+---
+
+## 4. LottieLoader pointer-events-none 적용 결정
+
+### 트레이드오프
+
+`pointer-events-none`을 적용하면 로딩 오버레이가 표시되는 **모든 상황**에서 하단 UI와 상호작용이 가능해집니다. 예를 들어 아레나 생성 요청 중에 다시 "도전장 작성하기"를 클릭하면 모달이 재오픈되어 중복 제출이 이론적으로 가능합니다.
+
+### 결정
+
+중복 제출 방지는 서버 측에서 처리하는 것이 올바른 책임 분리입니다(클라이언트 UI는 보조적 방어선). 현재 버그(버튼 클릭 자체가 막힘)가 더 심각한 UX 문제이므로 `pointer-events-none` 적용을 우선했습니다. 이 의도를 코드 주석으로 명시했습니다.
+
+---
+
+## 5. 점수 차감 서버 이전 결정
+
+### 기존 구조의 문제
+
+`CreateArenaModal`이 아레나 생성 후 클라이언트에서 직접 `POST /api/member/scores`를 호출해 점수를 차감하고 기록을 생성했습니다.
+
+**보안 취약점**: 클라이언트가 `policyId`, `actualScore`를 직접 전달하므로 임의 조작이 가능했습니다.
+
+**비원자성**: 아레나 생성과 점수 차감이 별개 요청이므로 네트워크 오류 시 데이터 불일치 발생 가능.
+
+### 결정: 서버에서 처리
+
+`POST /api/member/arenas` 핸들러에서 아레나 생성과 동시에 점수 차감(-100) 및 기록 생성(policyId: 4)을 처리. `policyId`와 `actualScore`는 서버에서 하드코딩되므로 클라이언트 조작 불가.
+
+---
+
+## 6. prisma.$transaction 도입 결정
+
+### ECC 리뷰에서 지적된 문제
+
+초기 구현에서 세 연산(아레나 생성 → 점수 차감 → 기록 생성)이 트랜잭션 없이 순차 실행되었습니다. ECC 리뷰에서 이를 [Critical]로 지적:
+
+- `incrementScore` 실패 시: 아레나는 생성됐지만 점수 미차감 (100점 비용 없이 아레나 획득)
+- `createRecord` 실패 시: 점수는 차감됐지만 이력 없음
+
+### 결정: prisma.$transaction 적용
+
+초기에는 후속 이슈(#307)로 분리했지만, 코드 한 줄 수준의 변경이어서 별도 이슈/브랜치 없이 fix/#301에서 처리하기로 결정하고 #307을 닫았습니다.
+
+트랜잭션 블록에서 리포지토리 추상화를 거치지 않고 `tx` 클라이언트를 직접 사용한 이유: 기존 리포지토리들이 `Prisma.TransactionClient`를 받는 인터페이스를 갖추지 않아, 트랜잭션 클라이언트를 주입하려면 리포지토리 전체 리팩터링이 필요합니다. 범위 대비 비용이 커서 라우트 핸들러에서 직접 처리하는 방향을 선택했습니다.
+
+---
+
+## 7. ECC 리뷰 반영 사항 (2차 커밋)
+
+| 항목 | ECC 지적 | 조치 |
+| --- | --- | --- |
+| z-[10001] 의도 불명 | 매직 넘버 주석 권장 | LottieLoader z-9999 위임을 주석으로 명시 |
+| pointer-events-none 광범위한 영향 | 의도된 동작이면 주석 권장 | 중복 제출은 서버가 방어함을 주석으로 명시 |
+| 트랜잭션 부재 | [Critical] 원자성 미보장 | prisma.$transaction 적용 후 #307 이슈 닫음 |
+| 새 동작 검증 테스트 부재 | incrementScore/createRecord 인자 검증 미흡 | 호출 인자(delta, policyId) 검증 테스트 추가 |

--- a/types/css.d.ts
+++ b/types/css.d.ts
@@ -1,0 +1,1 @@
+declare module "*.css";


### PR DESCRIPTION
## ✨ 작업 개요

도전장 작성하기 버튼 클릭 시 CreateArenaModal이 열리지 않는 버그를 수정합니다.

## ✅ 상세 내용

- [x] `ModalWrapper.tsx`: React 19 StrictMode 호환 수정
  - `focus-trap-react` cleanup 시 `onDeactivate: onClose`가 즉시 호출되어 모달이 열리자마자 닫히는 버그 수정
  - `onDeactivate` 제거, ESC 키 처리는 `useEffect` 리스너로 직접 구현
  - z-index `z-50` → `z-[10001]` (LottieLoader z-9999 위)
- [x] `LottieLoader.tsx`: `pointer-events-none` 추가
  - 로딩 오버레이가 버튼 클릭 이벤트를 차단하던 보조 원인 수정 (로딩 중 하단 UI 상호작용 허용, 중복 제출 방어는 서버에서 처리)
- [x] `CreateArenaModal.tsx`: 존재하지 않는 `POST /api/member/scores` 중복 호출 제거 (405 에러)
- [x] `app/api/member/arenas/route.ts`: 점수 차감(-100) 및 기록 생성을 서버에서 `prisma.$transaction`으로 원자적 처리
  - 클라이언트에서 `policyId`/`actualScore` 조작 가능한 보안 취약점 해소
  - 아레나 생성 · 점수 차감 · 기록 생성 세 연산의 원자성 보장
- [x] `route.test.ts`: `incrementScore`, `PrismaScoreRecordRepository` mock 추가, 호출 인자(`delta=-100`, `policyId=4`) 검증 테스트 추가 (ECC 리뷰 반영)
- [x] `types/css.d.ts`: CSS 모듈 타입 선언 추가

## 🧪 확인 사항

- [x] 정상적으로 동작하는지 직접 테스트해봤나요?
- [x] 기능 추가/수정 후 UI나 비즈니스 로직에 영향은 없나요?
- [ ] PR 리뷰어가 중점적으로 확인하면 좋을 부분은?
  - 도전장 작성하기 버튼 클릭 시 모달 정상 오픈 여부
  - 아레나 생성 후 포인트(-100) 차감 정상 동작 여부
  - ESC 키 및 배경 클릭으로 모달 닫기 정상 동작 여부

## 📚 참고자료

의사결정 기록: `docs/ecc/plans/arena-modal-bug-fix.md`

## 이슈 관리

close #301