### PR TITLE
[fix/#304] 회원가입 선호 설정 버그 수정

### DIFF
--- a/app/(auth)/components/SelectionCard.tsx
+++ b/app/(auth)/components/SelectionCard.tsx
@@ -12,7 +12,7 @@ export default function SelectionCard({
     return (
         <button
             onClick={onClick}
-            className={`// ✅ min-width로 변경해 반응형 대응 flex h-[80px] min-w-[140px] items-center justify-center whitespace-pre-wrap break-words rounded-xl border px-2 py-2 text-center text-sm font-medium leading-snug transition-all duration-150 ${
+            className={`flex h-[80px] min-w-[140px] items-center justify-center whitespace-pre-wrap break-words rounded-xl border px-2 py-2 text-center text-sm font-medium leading-snug transition-all duration-150 ${
                 selected
                     ? "border-primary-purple-100 bg-primary-purple-100 text-white"
                     : "border-font-200 bg-background-100 text-font-100 hover:bg-background-200"

--- a/app/(auth)/components/StepGenres.tsx
+++ b/app/(auth)/components/StepGenres.tsx
@@ -54,10 +54,6 @@ export default function StepGenres({ onNext, onBack }: Props) {
     };
 
     const handleNext = () => {
-        if (selectedGenreIds.length === 0) {
-            onNext();
-            return;
-        }
         saveGenres();
     };
 

--- a/app/(auth)/components/StepGenres.tsx
+++ b/app/(auth)/components/StepGenres.tsx
@@ -27,7 +27,7 @@ export default function StepGenres({ onNext, onBack }: Props) {
         queryFn: () => fetcher("/api/genres"),
     });
 
-    const { mutate: saveGenres } = useMutation({
+    const { mutate: saveGenres, isPending } = useMutation({
         mutationFn: () =>
             fetch("/api/preferred-genres", {
                 method: "POST",
@@ -92,6 +92,7 @@ export default function StepGenres({ onNext, onBack }: Props) {
                     size="medium"
                     type="purple"
                     onClick={handleNext}
+                    disabled={isPending}
                 />
             </div>
         </div>

--- a/app/(auth)/components/StepPlatforms.tsx
+++ b/app/(auth)/components/StepPlatforms.tsx
@@ -29,7 +29,7 @@ export default function StepPlatforms({ onSubmit, onBack }: Props) {
         queryFn: () => fetcher("/api/platforms"),
     });
 
-    const { mutate: savePlatforms } = useMutation({
+    const { mutate: savePlatforms, isPending } = useMutation({
         mutationFn: () =>
             fetch("/api/preferred-platforms", {
                 method: "POST",
@@ -95,6 +95,7 @@ export default function StepPlatforms({ onSubmit, onBack }: Props) {
                     size="medium"
                     type="purple"
                     onClick={handleSubmit}
+                    disabled={isPending}
                 />
             </div>
         </div>

--- a/app/(auth)/components/StepPlatforms.tsx
+++ b/app/(auth)/components/StepPlatforms.tsx
@@ -57,10 +57,6 @@ export default function StepPlatforms({ onSubmit, onBack }: Props) {
     };
 
     const handleSubmit = () => {
-        if (selectedPlatformIds.length === 0) {
-            onSubmit();
-            return;
-        }
         savePlatforms();
     };
 

--- a/app/(auth)/components/StepThemes.tsx
+++ b/app/(auth)/components/StepThemes.tsx
@@ -54,10 +54,6 @@ export default function StepThemes({ onNext, onBack }: Props) {
     };
 
     const handleNext = () => {
-        if (selectedThemeIds.length === 0) {
-            onNext();
-            return;
-        }
         saveThemes();
     };
 

--- a/app/(auth)/components/StepThemes.tsx
+++ b/app/(auth)/components/StepThemes.tsx
@@ -27,7 +27,7 @@ export default function StepThemes({ onNext, onBack }: Props) {
         queryFn: () => fetcher("/api/themes"),
     });
 
-    const { mutate: saveThemes } = useMutation({
+    const { mutate: saveThemes, isPending } = useMutation({
         mutationFn: () =>
             fetch("/api/preferred-themes", {
                 method: "POST",
@@ -92,6 +92,7 @@ export default function StepThemes({ onNext, onBack }: Props) {
                     size="medium"
                     type="purple"
                     onClick={handleNext}
+                    disabled={isPending}
                 />
             </div>
         </div>

--- a/app/(auth)/sign-up/page.tsx
+++ b/app/(auth)/sign-up/page.tsx
@@ -18,7 +18,7 @@ export default function Register() {
         "success" | "error" | "info"
     >("success");
 
-    const nextStep = () => setStep((prev) => Math.min(prev + 1, 5));
+    const nextStep = () => setStep((prev) => Math.min(prev + 1, 4));
     const prevStep = () => setStep((prev) => Math.max(prev - 1, 1));
 
     const handleSubmit = () => {

--- a/docs/superpowers/plans/2026-04-17-signup-preference-bug-fix.md
+++ b/docs/superpowers/plans/2026-04-17-signup-preference-bug-fix.md
@@ -1,0 +1,56 @@
+# 회원가입 선호 설정 버그 수정 Plan
+
+> **Status**: 🚧 In Progress — Issue #304, branch `fix/#304`
+
+**Goal:** 회원가입 선호 장르/테마/플랫폼 입력 흐름의 버그 3건 수정.
+
+**Architecture:** 프론트엔드 3개 파일(SelectionCard, page, Step 컴포넌트들)만 수정. 백엔드 무변경.
+
+**Tech Stack:** Next.js 15 App Router, React 19, TypeScript
+
+---
+
+## File Map
+
+| 파일                                            | 상태     | 역할                                       |
+| ----------------------------------------------- | -------- | ------------------------------------------ |
+| `app/(auth)/components/SelectionCard.tsx`       | **수정** | className 내 주석 문자열 제거              |
+| `app/(auth)/sign-up/page.tsx`                   | **수정** | `nextStep` 상한 5 → 4 수정                 |
+| `app/(auth)/components/StepGenres.tsx`          | **수정** | 빈 선택 시 API 스킵 제거, 항상 API 호출   |
+| `app/(auth)/components/StepThemes.tsx`          | **수정** | 빈 선택 시 API 스킵 제거, 항상 API 호출   |
+| `app/(auth)/components/StepPlatforms.tsx`       | **수정** | 빈 선택 시 API 스킵 제거, 항상 API 호출   |
+
+---
+
+## Task 1: SelectionCard className 주석 제거
+
+**Goal:** className 문자열에 포함된 `// ✅ min-width로 변경해 반응형 대응` 주석 제거.
+
+- [ ] **Step 1:** `SelectionCard.tsx:15` className 템플릿 리터럴에서 주석 텍스트 제거
+
+---
+
+## Task 2: nextStep 상한 수정
+
+**Goal:** `page.tsx`의 `nextStep` 함수가 step 5까지 허용하는 버그 수정.
+
+- [ ] **Step 1:** `page.tsx:21` — `Math.min(prev + 1, 5)` → `Math.min(prev + 1, 4)`
+
+---
+
+## Task 3: 빈 선택 시 API 스킵 로직 제거
+
+**Goal:** 선택 없이 다음 단계로 이동 시 항상 API를 호출하도록 수정.
+
+- [ ] **Step 1:** `StepGenres.tsx` `handleNext` — 빈 배열 조기 반환 제거, 항상 `saveGenres()` 호출
+- [ ] **Step 2:** `StepThemes.tsx` `handleNext` — 동일 수정
+- [ ] **Step 3:** `StepPlatforms.tsx` `handleSubmit` — 동일 수정
+
+> 서버 측 `CreatePreferredGenresUsecase`는 이미 `deleteMany` 후 빈 배열이면 INSERT 없이 종료하므로 백엔드 무변경.
+
+---
+
+## Task 4: 커밋
+
+- [ ] **Step 1:** 변경 파일 스테이징 (문서 포함)
+- [ ] **Step 2:** 커밋 메시지 `[fix/#304] 회원가입 선호 설정 버그 수정`

--- a/docs/superpowers/plans/2026-04-17-signup-preference-bug-fix.md
+++ b/docs/superpowers/plans/2026-04-17-signup-preference-bug-fix.md
@@ -1,6 +1,6 @@
 # 회원가입 선호 설정 버그 수정 Plan
 
-> **Status**: 🚧 In Progress — Issue #304, branch `fix/#304`
+> **Status**: ✅ Done — Issue #304, branch `fix/#304`
 
 **Goal:** 회원가입 선호 장르/테마/플랫폼 입력 흐름의 버그 3건 수정.
 
@@ -26,7 +26,7 @@
 
 **Goal:** className 문자열에 포함된 `// ✅ min-width로 변경해 반응형 대응` 주석 제거.
 
-- [ ] **Step 1:** `SelectionCard.tsx:15` className 템플릿 리터럴에서 주석 텍스트 제거
+- [x] **Step 1:** `SelectionCard.tsx:15` className 템플릿 리터럴에서 주석 텍스트 제거
 
 ---
 
@@ -34,7 +34,7 @@
 
 **Goal:** `page.tsx`의 `nextStep` 함수가 step 5까지 허용하는 버그 수정.
 
-- [ ] **Step 1:** `page.tsx:21` — `Math.min(prev + 1, 5)` → `Math.min(prev + 1, 4)`
+- [x] **Step 1:** `page.tsx:21` — `Math.min(prev + 1, 5)` → `Math.min(prev + 1, 4)`
 
 ---
 
@@ -42,9 +42,9 @@
 
 **Goal:** 선택 없이 다음 단계로 이동 시 항상 API를 호출하도록 수정.
 
-- [ ] **Step 1:** `StepGenres.tsx` `handleNext` — 빈 배열 조기 반환 제거, 항상 `saveGenres()` 호출
-- [ ] **Step 2:** `StepThemes.tsx` `handleNext` — 동일 수정
-- [ ] **Step 3:** `StepPlatforms.tsx` `handleSubmit` — 동일 수정
+- [x] **Step 1:** `StepGenres.tsx` `handleNext` — 빈 배열 조기 반환 제거, 항상 `saveGenres()` 호출
+- [x] **Step 2:** `StepThemes.tsx` `handleNext` — 동일 수정
+- [x] **Step 3:** `StepPlatforms.tsx` `handleSubmit` — 동일 수정
 
 > 서버 측 `CreatePreferredGenresUsecase`는 이미 `deleteMany` 후 빈 배열이면 INSERT 없이 종료하므로 백엔드 무변경.
 
@@ -52,5 +52,5 @@
 
 ## Task 4: 커밋
 
-- [ ] **Step 1:** 변경 파일 스테이징 (문서 포함)
-- [ ] **Step 2:** 커밋 메시지 `[fix/#304] 회원가입 선호 설정 버그 수정`
+- [x] **Step 1:** 변경 파일 스테이징 (문서 포함)
+- [x] **Step 2:** 커밋 메시지 `[fix/#304] 회원가입 선호 설정 버그 수정`

--- a/docs/superpowers/specs/2026-04-17-signup-preference-bug-fix-design.md
+++ b/docs/superpowers/specs/2026-04-17-signup-preference-bug-fix-design.md
@@ -1,0 +1,121 @@
+# 회원가입 선호 설정 버그 수정 Design
+
+**Date**: 2026-04-17
+**Status**: In Progress
+**Branch**: `fix/#304`
+**Issue**: #304
+
+---
+
+## Problem
+
+회원가입 선호 장르/테마/플랫폼 입력 단계에서 발견된 버그 3건.
+
+### Bug 1 — SelectionCard className에 주석 포함
+
+```tsx
+// SelectionCard.tsx:15
+className={`// ✅ min-width로 변경해 반응형 대응 flex h-[80px] min-w-[140px] ...`}
+```
+
+`// ✅ min-width로 변경해 반응형 대응` 문자열이 className에 그대로 포함되어 DOM에 출력됨.
+CSS 클래스로 해석되지 않아 무해하지만, 불필요한 문자열이 마크업에 노출되는 코드 품질 문제.
+
+### Bug 2 — nextStep 상한이 5로 설정
+
+```tsx
+// page.tsx:21
+const nextStep = () => setStep((prev) => Math.min(prev + 1, 5));
+```
+
+실제 step은 최대 4(StepPlatforms)까지만 존재. 상한이 5이므로 이론상 step 5에 도달 가능.
+step 5에 해당하는 렌더링 분기가 없어 빈 화면이 표시되는 잠재 버그.
+
+### Bug 3 — 빈 선택 시 기존 데이터 미삭제
+
+```tsx
+// StepGenres.tsx
+const handleNext = () => {
+    if (selectedGenreIds.length === 0) {
+        onNext(); // API 호출 없이 스킵
+        return;
+    }
+    saveGenres();
+};
+```
+
+아무것도 선택하지 않고 다음 단계로 이동하면 API를 호출하지 않아 기존 저장된 선호 데이터가 삭제되지 않음.
+현재 회원가입 최초 진행 시에는 기존 데이터가 없어 즉각적 문제는 없지만,
+이 컴포넌트를 "선호 설정 수정" 페이지에서 재사용할 경우 기존 데이터가 남아 있게 됨.
+
+---
+
+## Decisions
+
+| 질문 | 결정 | 근거 |
+| --- | --- | --- |
+| Bug 3 수정 위치: 프론트 vs 백엔드 | 프론트에서 early return 제거 | 서버 UseCase는 이미 `deleteMany` 후 빈 배열이면 INSERT 없이 종료. 백엔드 로직 정상 |
+| 빈 배열 전송 시 서버 동작 | 정상 처리 (200 OK) | `z.array()` 기본 동작상 빈 배열 허용, UseCase는 delete 후 루프 없이 종료 |
+| Zod 스키마 변경 여부 | 변경 안 함 | 빈 배열은 유효한 입력 (선호 항목 없음을 의미) |
+
+---
+
+## Architecture
+
+### Bug 1 수정
+
+```tsx
+// 수정 전
+className={`// ✅ min-width로 변경해 반응형 대응 flex h-[80px] min-w-[140px] ...`}
+
+// 수정 후
+className={`flex h-[80px] min-w-[140px] ...`}
+```
+
+### Bug 2 수정
+
+```tsx
+// 수정 전
+const nextStep = () => setStep((prev) => Math.min(prev + 1, 5));
+
+// 수정 후
+const nextStep = () => setStep((prev) => Math.min(prev + 1, 4));
+```
+
+### Bug 3 수정 (StepGenres / StepThemes / StepPlatforms 동일)
+
+```tsx
+// 수정 전
+const handleNext = () => {
+    if (selectedGenreIds.length === 0) {
+        onNext();
+        return;
+    }
+    saveGenres();
+};
+
+// 수정 후
+const handleNext = () => {
+    saveGenres();
+};
+```
+
+---
+
+## Out of Scope
+
+- N+1 INSERT 쿼리 개선 (→ refactor #305)
+- Step 컴포넌트 3벌 중복 통합 (→ refactor #305)
+- Domain / Prisma 타입 의존 분리 (→ refactor #305)
+
+---
+
+## Affected Files
+
+| 파일 | 변경 |
+| --- | --- |
+| `app/(auth)/components/SelectionCard.tsx` | className 주석 제거 |
+| `app/(auth)/sign-up/page.tsx` | `nextStep` 상한 5 → 4 |
+| `app/(auth)/components/StepGenres.tsx` | `handleNext` 빈 배열 조기 반환 제거 |
+| `app/(auth)/components/StepThemes.tsx` | `handleNext` 빈 배열 조기 반환 제거 |
+| `app/(auth)/components/StepPlatforms.tsx` | `handleSubmit` 빈 배열 조기 반환 제거 |


### PR DESCRIPTION
## ✨ 작업 개요

회원가입 선호 장르/테마/플랫폼 입력 단계에서 발견된 버그 3건 수정

## ✅ 상세 내용

- [x] **`SelectionCard.tsx`** — `className` 템플릿 리터럴 안에 `// ✅ min-width로 변경해 반응형 대응` 주석이 문자열로 포함되어 DOM에 그대로 출력되던 문제 제거
- [x] **`page.tsx`** — `nextStep` 상한이 `5`로 설정되어 실제 step 최대값(4)을 초과 가능하던 문제를 `Math.min(prev + 1, 4)`로 수정
- [x] **`StepGenres/StepThemes/StepPlatforms.tsx`** — 선택 없이 다음 단계로 이동 시 API를 스킵하는 early return 제거. 항상 API를 호출하여 기존 저장 데이터가 확실히 삭제되도록 수정
  - 서버 측 UseCase는 이미 `deleteMany` 후 빈 배열이면 INSERT 없이 종료하므로 백엔드 무변경

## 📸 스크린샷 (선택)

## 🧪 확인 사항

- [x] 정상적으로 동작하는지 직접 테스트해봤나요?
- [x] 기능 추가/수정 후 UI나 비즈니스 로직에 영향은 없나요?
- [ ] PR 리뷰어가 중점적으로 확인하면 좋을 부분은?
  - Bug 3(빈 선택 시 API 강제 호출)로 인해 회원가입 흐름에서 아무것도 선택 안 해도 API 요청이 발생하는 점 — 서버는 정상 처리하지만 불필요한 네트워크 요청이 추가됨

## 🙏 기타 참고 사항

- 관련 리팩토링(N+1 쿼리, Step 컴포넌트 중복, Domain/Prisma 의존 분리)은 issue #305에서 별도 처리 예정

## 이슈 관리

close #304