### PR TITLE
[feat/#308] 알림 읽음 상태 관리 및 P0/P1 알림 트리거

### DIFF
--- a/app/(base)/components/NotificationModal.tsx
+++ b/app/(base)/components/NotificationModal.tsx
@@ -1,34 +1,67 @@
-// app/(base)/components/NotificationModal.tsx
 "use client";
 
-import React, { useState } from "react";
+import { useState } from "react";
+import { X } from "lucide-react";
 import ModalWrapper from "@/app/components/ModalWrapper";
 import useModalStore from "@/stores/ModalStore";
 import Pager from "@/app/components/Pager";
 import NotificationRecordList from "./NotificationRecordList";
 import { useNotifications } from "@/hooks/useNotifications";
+import { useNotificationCount } from "@/hooks/useNotificationCount";
 
 export default function NotificationModal() {
     const { isOpen, closeModal } = useModalStore();
     const [currentPage, setCurrentPage] = useState(1);
-    const { data } = useNotifications(currentPage);
+    const { data, isLoading } = useNotifications(currentPage);
+    const { data: countData } = useNotificationCount();
+    const unreadCount = countData?.count ?? 0;
 
     return (
         <ModalWrapper
             isOpen={isOpen}
             onClose={closeModal}
             labelId="notification-modal-title"
+            dialogClassName="max-w-[460px]"
         >
-            <div className="flex max-h-[80vh] w-[480px] flex-col gap-4">
-                <h2 id="notification-modal-title" className="sr-only">
-                    알림
-                </h2>
-                {data && (
-                    <div>
+            <div className="flex w-full flex-col gap-4">
+                <div className="flex items-center justify-between border-b border-white/10 pb-4">
+                    <div className="flex items-center gap-2">
+                        <h2
+                            id="notification-modal-title"
+                            className="text-h3 font-bold text-font-100"
+                        >
+                            알림
+                        </h2>
+                        {unreadCount > 0 && (
+                            <span className="flex h-5 min-w-5 items-center justify-center rounded-full bg-primary-purple-200 px-1.5 text-[11px] font-bold text-white">
+                                {unreadCount > 99 ? "99+" : unreadCount}
+                            </span>
+                        )}
+                    </div>
+                    <button
+                        onClick={closeModal}
+                        className="rounded-lg p-1.5 text-font-200 transition-colors hover:bg-white/10 hover:text-font-100"
+                        aria-label="알림 닫기"
+                    >
+                        <X size={18} />
+                    </button>
+                </div>
+
+                {isLoading ? (
+                    <div className="flex flex-col gap-1.5 py-1">
+                        {Array.from({ length: 4 }).map((_, i) => (
+                            <div
+                                key={i}
+                                className="h-[72px] w-full animate-pulse rounded-lg bg-background-200"
+                            />
+                        ))}
+                    </div>
+                ) : (
+                    <div className="flex flex-col gap-3">
                         <NotificationRecordList
-                            notificationRecords={data.records}
+                            notificationRecords={data?.records ?? []}
                         />
-                        {data.records.length > 0 && (
+                        {data && data.endPage > 1 && (
                             <Pager
                                 currentPage={data.currentPage}
                                 pages={data.pages}

--- a/app/(base)/components/NotificationModal.tsx
+++ b/app/(base)/components/NotificationModal.tsx
@@ -33,7 +33,7 @@ export default function NotificationModal() {
                             알림
                         </h2>
                         {unreadCount > 0 && (
-                            <span className="flex h-5 min-w-5 items-center justify-center rounded-full bg-primary-purple-200 px-1.5 text-[11px] font-bold text-white">
+                            <span className="flex h-5 min-w-5 items-center justify-center rounded-full bg-primary-purple-200 px-1.5 text-caption font-bold text-white">
                                 {unreadCount > 99 ? "99+" : unreadCount}
                             </span>
                         )}

--- a/app/(base)/components/NotificationModal.tsx
+++ b/app/(base)/components/NotificationModal.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState } from "react";
+import { useEffect, useState } from "react";
 import { X } from "lucide-react";
 import ModalWrapper from "@/app/components/ModalWrapper";
 import useModalStore from "@/stores/ModalStore";
@@ -12,6 +12,10 @@ import { useNotificationCount } from "@/hooks/useNotificationCount";
 export default function NotificationModal() {
     const { isOpen, closeModal } = useModalStore();
     const [currentPage, setCurrentPage] = useState(1);
+
+    useEffect(() => {
+        if (!isOpen) setCurrentPage(1);
+    }, [isOpen]);
     const { data, isLoading } = useNotifications(currentPage);
     const { data: countData } = useNotificationCount();
     const unreadCount = countData?.count ?? 0;

--- a/app/(base)/components/NotificationRecordItem.tsx
+++ b/app/(base)/components/NotificationRecordItem.tsx
@@ -3,18 +3,20 @@
 import React from "react";
 import Image from "next/image";
 import { useMutation, useQueryClient } from "@tanstack/react-query";
+import { useRouter } from "next/navigation";
 import { queryKeys } from "@/lib/QueryKeys";
-
 import { NotificationRecordDto } from "@/backend/notification-record/application/usecase/dto/NotificationRecordDto";
 
 type NotificationRecordItemProps = {
     notificationRecordDto: NotificationRecordDto;
+    href?: string;
 };
 
 export default function NotificationRecordItem(
     props: NotificationRecordItemProps
 ) {
     const queryClient = useQueryClient();
+    const router = useRouter();
     const notificationRecordDto: NotificationRecordDto =
         props.notificationRecordDto;
     const createdAt = new Date(notificationRecordDto.createdAt);
@@ -25,6 +27,18 @@ export default function NotificationRecordItem(
         String(createdAt.getHours())
     )}:${pad(String(createdAt.getMinutes()))}`;
 
+    const { mutate: markRead } = useMutation({
+        mutationFn: () =>
+            fetch(`/api/member/notification-records/${notificationRecordDto.id}`, {
+                method: "PATCH",
+            }),
+        onSuccess: () => {
+            queryClient.invalidateQueries({ queryKey: queryKeys.notifications() });
+            queryClient.invalidateQueries({ queryKey: queryKeys.notificationCount() });
+            router.push(props.href ?? "#");
+        },
+    });
+
     const { mutate: deleteNotification } = useMutation({
         mutationFn: (id: number) =>
             fetch(`/api/member/notification-records/${id}`, {
@@ -32,17 +46,27 @@ export default function NotificationRecordItem(
                 headers: { "Content-Type": "application/json" },
             }),
         onSuccess: () => {
-            queryClient.invalidateQueries({
-                queryKey: queryKeys.notifications(1),
-            });
+            queryClient.invalidateQueries({ queryKey: queryKeys.notifications() });
+            queryClient.invalidateQueries({ queryKey: queryKeys.notificationCount() });
         },
     });
 
+    const handleClick = () => {
+        const href = props.href ?? "#";
+        if (!notificationRecordDto.isRead) {
+            markRead();
+        } else {
+            router.push(href);
+        }
+    };
+
     return (
-        <div className="relative w-full rounded-lg bg-background-300 p-2.5 transition-colors hover:outline hover:outline-1 hover:outline-primary-purple-200">
-            {/* 메시지와 우측 정보 영역을 flex로 정렬 */}
+        <div
+            className="relative w-full cursor-pointer rounded-lg bg-background-300 p-2.5 transition-colors hover:outline hover:outline-1 hover:outline-primary-purple-200"
+            style={{ opacity: notificationRecordDto.isRead ? 0.6 : 1 }}
+            onClick={handleClick}
+        >
             <div className="flex items-start justify-between gap-4">
-                {/* 왼쪽: 아이콘 + 메시지 */}
                 <div className="flex items-start gap-4">
                     <div className="mt-1 h-6 min-h-[24px] w-6 min-w-[24px]">
                         <Image
@@ -64,14 +88,14 @@ export default function NotificationRecordItem(
                     </div>
                 </div>
 
-                {/* 오른쪽: 날짜 + 삭제 버튼 (중앙 정렬) */}
                 <div className="flex min-w-max flex-col items-end justify-center gap-2 text-caption text-font-200">
                     <span>{formattedDate}</span>
                     <button
                         className="hover:text-white"
-                        onClick={() =>
-                            deleteNotification(notificationRecordDto.id)
-                        }
+                        onClick={(e) => {
+                            e.stopPropagation();
+                            deleteNotification(notificationRecordDto.id);
+                        }}
                     >
                         <Image
                             src="/icons/delete.svg"

--- a/app/(base)/components/NotificationRecordItem.tsx
+++ b/app/(base)/components/NotificationRecordItem.tsx
@@ -29,10 +29,13 @@ export default function NotificationRecordItem({ notificationRecordDto }: Props)
     const queryClient = useQueryClient();
 
     const { mutate: markRead, isPending: isMarking } = useMutation({
-        mutationFn: () =>
-            fetch(`/api/member/notification-records/${notificationRecordDto.id}`, {
-                method: "PATCH",
-            }),
+        mutationFn: async () => {
+            const res = await fetch(
+                `/api/member/notification-records/${notificationRecordDto.id}`,
+                { method: "PATCH" }
+            );
+            if (!res.ok) throw new Error((await res.json()).message ?? "요청 실패");
+        },
         onSuccess: () => {
             queryClient.invalidateQueries({ queryKey: queryKeys.notifications() });
             queryClient.invalidateQueries({ queryKey: queryKeys.notificationCount() });
@@ -40,11 +43,13 @@ export default function NotificationRecordItem({ notificationRecordDto }: Props)
     });
 
     const { mutate: deleteNotification, isPending: isDeleting } = useMutation({
-        mutationFn: (id: number) =>
-            fetch(`/api/member/notification-records/${id}`, {
+        mutationFn: async (id: number) => {
+            const res = await fetch(`/api/member/notification-records/${id}`, {
                 method: "DELETE",
                 headers: { "Content-Type": "application/json" },
-            }),
+            });
+            if (!res.ok) throw new Error((await res.json()).message ?? "요청 실패");
+        },
         onSuccess: () => {
             queryClient.invalidateQueries({ queryKey: queryKeys.notifications() });
             queryClient.invalidateQueries({ queryKey: queryKeys.notificationCount() });

--- a/app/(base)/components/NotificationRecordItem.tsx
+++ b/app/(base)/components/NotificationRecordItem.tsx
@@ -1,33 +1,34 @@
 "use client";
 
-import React from "react";
 import Image from "next/image";
 import { useMutation, useQueryClient } from "@tanstack/react-query";
-import { useRouter } from "next/navigation";
+import { cn } from "@/utils/TailwindUtil";
 import { queryKeys } from "@/lib/QueryKeys";
-import { NotificationRecordDto } from "@/backend/notification-record/application/usecase/dto/NotificationRecordDto";
+import type { NotificationRecordDto } from "@/backend/notification-record/application/usecase/dto/NotificationRecordDto";
 
-type NotificationRecordItemProps = {
+type Props = {
     notificationRecordDto: NotificationRecordDto;
-    href?: string;
 };
 
-export default function NotificationRecordItem(
-    props: NotificationRecordItemProps
-) {
-    const queryClient = useQueryClient();
-    const router = useRouter();
-    const notificationRecordDto: NotificationRecordDto =
-        props.notificationRecordDto;
-    const createdAt = new Date(notificationRecordDto.createdAt);
-    const pad = (str: string) => str.toString().padStart(2, "0");
-    const formattedDate = `${createdAt.getFullYear()}-${pad(
-        String(createdAt.getMonth() + 1)
-    )}-${pad(String(createdAt.getDate()))} ${pad(
-        String(createdAt.getHours())
-    )}:${pad(String(createdAt.getMinutes()))}`;
+function getRelativeTime(date: Date): string {
+    const diff = Date.now() - date.getTime();
+    const minutes = Math.floor(diff / 60_000);
+    const hours = Math.floor(minutes / 60);
+    const days = Math.floor(hours / 24);
 
-    const { mutate: markRead } = useMutation({
+    if (minutes < 1) return "방금";
+    if (minutes < 60) return `${minutes}분 전`;
+    if (hours < 24) return `${hours}시간 전`;
+    if (days < 7) return `${days}일 전`;
+
+    const pad = (n: number) => String(n).padStart(2, "0");
+    return `${date.getFullYear()}-${pad(date.getMonth() + 1)}-${pad(date.getDate())}`;
+}
+
+export default function NotificationRecordItem({ notificationRecordDto }: Props) {
+    const queryClient = useQueryClient();
+
+    const { mutate: markRead, isPending: isMarking } = useMutation({
         mutationFn: () =>
             fetch(`/api/member/notification-records/${notificationRecordDto.id}`, {
                 method: "PATCH",
@@ -35,11 +36,10 @@ export default function NotificationRecordItem(
         onSuccess: () => {
             queryClient.invalidateQueries({ queryKey: queryKeys.notifications() });
             queryClient.invalidateQueries({ queryKey: queryKeys.notificationCount() });
-            router.push(props.href ?? "#");
         },
     });
 
-    const { mutate: deleteNotification } = useMutation({
+    const { mutate: deleteNotification, isPending: isDeleting } = useMutation({
         mutationFn: (id: number) =>
             fetch(`/api/member/notification-records/${id}`, {
                 method: "DELETE",
@@ -51,61 +51,63 @@ export default function NotificationRecordItem(
         },
     });
 
-    const handleClick = () => {
-        const href = props.href ?? "#";
-        if (!notificationRecordDto.isRead) {
-            markRead();
-        } else {
-            router.push(href);
-        }
-    };
+    const isPending = isMarking || isDeleting;
+    const createdAt = new Date(notificationRecordDto.createdAt);
 
     return (
         <div
-            className="relative w-full cursor-pointer rounded-lg bg-background-300 p-2.5 transition-colors hover:outline hover:outline-1 hover:outline-primary-purple-200"
-            style={{ opacity: notificationRecordDto.isRead ? 0.6 : 1 }}
-            onClick={handleClick}
+            className={cn(
+                "relative flex items-start gap-3 rounded-lg border-l-2 bg-background-200 p-3 transition-opacity",
+                notificationRecordDto.isRead
+                    ? "border-transparent opacity-60"
+                    : "border-primary-purple-200",
+                !notificationRecordDto.isRead &&
+                    !isPending &&
+                    "cursor-pointer hover:bg-background-200/80",
+                isPending && "pointer-events-none opacity-40"
+            )}
+            onClick={() => {
+                if (!notificationRecordDto.isRead && !isPending) markRead();
+            }}
         >
-            <div className="flex items-start justify-between gap-4">
-                <div className="flex items-start gap-4">
-                    <div className="mt-1 h-6 min-h-[24px] w-6 min-w-[24px]">
-                        <Image
-                            src={notificationRecordDto.typeImageUrl}
-                            alt="알림 아이콘"
-                            width={24}
-                            height={24}
-                            className="object-contain"
-                        />
-                    </div>
-
-                    <div className="flex flex-col gap-1 text-font-100">
-                        <span className="text-body font-semibold">
-                            {notificationRecordDto.typeName}
-                        </span>
-                        <span className="font-small text-caption text-font-200">
-                            {notificationRecordDto.description}
-                        </span>
-                    </div>
-                </div>
-
-                <div className="flex min-w-max flex-col items-end justify-center gap-2 text-caption text-font-200">
-                    <span>{formattedDate}</span>
-                    <button
-                        className="hover:text-white"
-                        onClick={(e) => {
-                            e.stopPropagation();
-                            deleteNotification(notificationRecordDto.id);
-                        }}
-                    >
-                        <Image
-                            src="/icons/delete.svg"
-                            alt="삭제"
-                            width={24}
-                            height={24}
-                        />
-                    </button>
-                </div>
+            <div className="mt-0.5 h-8 w-8 shrink-0 overflow-hidden rounded-full bg-background-300 p-1.5">
+                <Image
+                    src={notificationRecordDto.typeImageUrl}
+                    alt=""
+                    width={20}
+                    height={20}
+                    className="h-full w-full object-contain"
+                />
             </div>
+
+            <div className="flex min-w-0 flex-1 flex-col gap-0.5">
+                <div className="flex items-center gap-2">
+                    <span className="text-button font-semibold text-font-100">
+                        {notificationRecordDto.typeName}
+                    </span>
+                    {!notificationRecordDto.isRead && (
+                        <span className="h-1.5 w-1.5 shrink-0 rounded-full bg-primary-purple-200" />
+                    )}
+                </div>
+                <span className="truncate text-caption text-font-200">
+                    {notificationRecordDto.description}
+                </span>
+                <span className="mt-0.5 text-caption text-font-300">
+                    {getRelativeTime(createdAt)}
+                </span>
+            </div>
+
+            <button
+                className="shrink-0 rounded p-1 text-font-300 transition-colors hover:bg-white/10 hover:text-font-100 disabled:opacity-40"
+                aria-label="알림 삭제"
+                disabled={isPending}
+                onClick={(e) => {
+                    e.stopPropagation();
+                    deleteNotification(notificationRecordDto.id);
+                }}
+            >
+                <Image src="/icons/delete.svg" alt="" width={16} height={16} />
+            </button>
         </div>
     );
 }

--- a/app/(base)/components/NotificationRecordList.tsx
+++ b/app/(base)/components/NotificationRecordList.tsx
@@ -1,43 +1,45 @@
 "use client";
-import React from "react";
+
 import Image from "next/image";
 import NotificationRecordItem from "./NotificationRecordItem";
-import { NotificationRecordDto } from "@/backend/notification-record/application/usecase/dto/NotificationRecordDto";
+import type { NotificationRecordDto } from "@/backend/notification-record/application/usecase/dto/NotificationRecordDto";
 
-type NotificationRecordListProps = {
+type Props = {
     notificationRecords: NotificationRecordDto[];
 };
 
-export default function NotificationRecordList(
-    props: NotificationRecordListProps
-) {
+export default function NotificationRecordList({ notificationRecords }: Props) {
+    if (notificationRecords.length === 0) {
+        return (
+            <div className="flex flex-col items-center justify-center gap-4 py-12">
+                <div className="flex h-16 w-16 items-center justify-center rounded-full bg-background-200">
+                    <Image
+                        src="/icons/bell.svg"
+                        alt=""
+                        width={28}
+                        height={28}
+                        className="opacity-40"
+                    />
+                </div>
+                <div className="flex flex-col items-center gap-1 text-center">
+                    <span className="text-body font-medium text-font-200">
+                        알림이 없어요
+                    </span>
+                    <span className="text-caption text-font-300">
+                        새로운 알림이 생기면 여기에 표시됩니다.
+                    </span>
+                </div>
+            </div>
+        );
+    }
+
     return (
-        <div className="flex w-full flex-col items-center justify-center gap-9">
-            <ol className="m-0 flex w-full list-none flex-col gap-6 p-0">
-                {props.notificationRecords.length === 0 ? (
-                    <li className="font-regular flex w-full flex-col items-center justify-center gap-4 text-center text-body text-font-200">
-                        <Image
-                            src="/images/empty.png"
-                            alt="새 알림 없음 이미지"
-                            width={200}
-                            height={200}
-                            className="-order-1"
-                            priority={true}
-                        />
-                        새로운 알림이 없어요.
-                    </li>
-                ) : (
-                    props.notificationRecords.map(
-                        (record: NotificationRecordDto) => (
-                            <li key={record.id}>
-                                <NotificationRecordItem
-                                    notificationRecordDto={record}
-                                />
-                            </li>
-                        )
-                    )
-                )}
-            </ol>
-        </div>
+        <ol className="flex w-full list-none flex-col gap-1.5 p-0">
+            {notificationRecords.map((record) => (
+                <li key={record.id}>
+                    <NotificationRecordItem notificationRecordDto={record} />
+                </li>
+            ))}
+        </ol>
     );
 }

--- a/app/(base)/components/__tests__/NotificationModal.test.tsx
+++ b/app/(base)/components/__tests__/NotificationModal.test.tsx
@@ -1,0 +1,148 @@
+// @vitest-environment jsdom
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen } from "@testing-library/react";
+import NotificationModal from "../NotificationModal";
+import type { NotificationRecordDto } from "@/backend/notification-record/application/usecase/dto/NotificationRecordDto";
+
+vi.mock("@/stores/ModalStore", () => ({
+    default: vi.fn(),
+}));
+
+vi.mock("@/hooks/useNotifications", () => ({
+    useNotifications: vi.fn(),
+}));
+
+vi.mock("@/hooks/useNotificationCount", () => ({
+    useNotificationCount: vi.fn(),
+}));
+
+vi.mock("@/app/components/ModalWrapper", () => ({
+    default: ({
+        isOpen,
+        children,
+    }: {
+        isOpen: boolean;
+        children: React.ReactNode;
+    }) => (isOpen ? <div role="dialog">{children}</div> : null),
+}));
+
+vi.mock("@/app/(base)/components/NotificationRecordList", () => ({
+    default: ({
+        notificationRecords,
+    }: {
+        notificationRecords: NotificationRecordDto[];
+    }) => <div data-testid="notification-list">{notificationRecords.length}개</div>,
+}));
+
+vi.mock("@/app/components/Pager", () => ({
+    default: () => <div data-testid="pager" />,
+}));
+
+import useModalStore from "@/stores/ModalStore";
+import { useNotifications } from "@/hooks/useNotifications";
+import { useNotificationCount } from "@/hooks/useNotificationCount";
+
+const emptyListResult = {
+    data: { records: [], totalCount: 0, currentPage: 1, pages: [1], endPage: 1 },
+    isLoading: false,
+};
+
+describe("NotificationModal", () => {
+    beforeEach(() => {
+        vi.mocked(useModalStore).mockReturnValue({
+            isOpen: true,
+            closeModal: vi.fn(),
+        } as ReturnType<typeof useModalStore>);
+        vi.mocked(useNotificationCount).mockReturnValue({
+            data: { count: 0 },
+        } as ReturnType<typeof useNotificationCount>);
+    });
+
+    it("isLoading이면 스켈레톤 4개를 렌더링한다", () => {
+        vi.mocked(useNotifications).mockReturnValue({
+            isLoading: true,
+            data: undefined,
+        } as ReturnType<typeof useNotifications>);
+
+        const { container } = render(<NotificationModal />);
+
+        expect(container.querySelectorAll(".animate-pulse")).toHaveLength(4);
+    });
+
+    it("빈 알림 목록이면 NotificationRecordList에 빈 배열을 전달한다", () => {
+        vi.mocked(useNotifications).mockReturnValue(
+            emptyListResult as ReturnType<typeof useNotifications>
+        );
+
+        render(<NotificationModal />);
+
+        expect(screen.getByTestId("notification-list").textContent).toBe("0개");
+    });
+
+    it("알림이 있으면 NotificationRecordList에 해당 개수를 전달한다", () => {
+        const records: NotificationRecordDto[] = [
+            {
+                id: 1,
+                memberId: "m1",
+                typeId: 1,
+                description: "알림1",
+                isRead: false,
+                createdAt: new Date(),
+                typeName: "티어 승급",
+                typeImageUrl: "/icon.svg",
+            },
+            {
+                id: 2,
+                memberId: "m1",
+                typeId: 2,
+                description: "알림2",
+                isRead: true,
+                createdAt: new Date(),
+                typeName: "티어 강등",
+                typeImageUrl: "/icon.svg",
+            },
+        ];
+        vi.mocked(useNotifications).mockReturnValue({
+            data: { records, totalCount: 2, currentPage: 1, pages: [1], endPage: 1 },
+            isLoading: false,
+        } as ReturnType<typeof useNotifications>);
+
+        render(<NotificationModal />);
+
+        expect(screen.getByTestId("notification-list").textContent).toBe("2개");
+    });
+
+    it("endPage > 1이면 Pager를 렌더링한다", () => {
+        vi.mocked(useNotifications).mockReturnValue({
+            data: { records: [], totalCount: 6, currentPage: 1, pages: [1, 2], endPage: 2 },
+            isLoading: false,
+        } as ReturnType<typeof useNotifications>);
+
+        render(<NotificationModal />);
+
+        expect(screen.getByTestId("pager")).toBeDefined();
+    });
+
+    it("endPage가 1이면 Pager를 렌더링하지 않는다", () => {
+        vi.mocked(useNotifications).mockReturnValue(
+            emptyListResult as ReturnType<typeof useNotifications>
+        );
+
+        render(<NotificationModal />);
+
+        expect(screen.queryByTestId("pager")).toBeNull();
+    });
+
+    it("미읽음 count가 양수이면 뱃지에 숫자를 표시한다", () => {
+        vi.mocked(useNotificationCount).mockReturnValue({
+            data: { count: 3 },
+        } as ReturnType<typeof useNotificationCount>);
+        vi.mocked(useNotifications).mockReturnValue(
+            emptyListResult as ReturnType<typeof useNotifications>
+        );
+
+        render(<NotificationModal />);
+
+        expect(screen.getByText("3")).toBeDefined();
+    });
+});

--- a/app/(base)/components/__tests__/NotificationRecordItem.test.tsx
+++ b/app/(base)/components/__tests__/NotificationRecordItem.test.tsx
@@ -1,0 +1,91 @@
+// @vitest-environment jsdom
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { render, screen, fireEvent, waitFor } from "@testing-library/react";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import NotificationRecordItem from "../NotificationRecordItem";
+import type { NotificationRecordDto } from "@/backend/notification-record/application/usecase/dto/NotificationRecordDto";
+
+vi.mock("next/image", () => ({
+    default: (props: React.ImgHTMLAttributes<HTMLImageElement>) => (
+        // eslint-disable-next-line @next/next/no-img-element, jsx-a11y/alt-text
+        <img {...props} />
+    ),
+}));
+
+const mockRecord: NotificationRecordDto = {
+    id: 1,
+    memberId: "member-1",
+    typeId: 1,
+    description: "테스트 알림입니다",
+    isRead: false,
+    createdAt: new Date("2026-01-01"),
+    typeName: "티어 승급",
+    typeImageUrl: "/icons/tier.svg",
+};
+
+function makeWrapper() {
+    const client = new QueryClient({
+        defaultOptions: {
+            mutations: { retry: false },
+            queries: { retry: false },
+        },
+    });
+    return function Wrapper({ children }: { children: React.ReactNode }) {
+        return <QueryClientProvider client={client}>{children}</QueryClientProvider>;
+    };
+}
+
+describe("NotificationRecordItem", () => {
+    beforeEach(() => {
+        vi.spyOn(globalThis, "fetch").mockResolvedValue({
+            ok: true,
+            json: async () => ({}),
+        } as Response);
+    });
+
+    afterEach(() => {
+        vi.restoreAllMocks();
+    });
+
+    it("읽지 않은 알림 클릭 시 PATCH 요청을 보낸다", async () => {
+        render(<NotificationRecordItem notificationRecordDto={mockRecord} />, {
+            wrapper: makeWrapper(),
+        });
+
+        fireEvent.click(screen.getByText("테스트 알림입니다"));
+
+        await waitFor(() => {
+            expect(fetch).toHaveBeenCalledWith("/api/member/notification-records/1", {
+                method: "PATCH",
+            });
+        });
+    });
+
+    it("이미 읽은 알림 클릭 시 PATCH 요청을 보내지 않는다", () => {
+        render(
+            <NotificationRecordItem
+                notificationRecordDto={{ ...mockRecord, isRead: true }}
+            />,
+            { wrapper: makeWrapper() }
+        );
+
+        fireEvent.click(screen.getByText("테스트 알림입니다"));
+
+        expect(fetch).not.toHaveBeenCalled();
+    });
+
+    it("삭제 버튼 클릭 시 DELETE 요청을 보낸다", async () => {
+        render(<NotificationRecordItem notificationRecordDto={mockRecord} />, {
+            wrapper: makeWrapper(),
+        });
+
+        fireEvent.click(screen.getByRole("button", { name: "알림 삭제" }));
+
+        await waitFor(() => {
+            expect(fetch).toHaveBeenCalledWith("/api/member/notification-records/1", {
+                method: "DELETE",
+                headers: { "Content-Type": "application/json" },
+            });
+        });
+    });
+});

--- a/app/api/member/arenas/[id]/join/__tests__/route.test.ts
+++ b/app/api/member/arenas/[id]/join/__tests__/route.test.ts
@@ -28,7 +28,11 @@ vi.mock(
         PrismaMemberRepository: vi.fn(function (this: Record<string, unknown>) {
             this.findById = vi
                 .fn()
-                .mockResolvedValue({ id: "user-id", score: 200, nickname: "테스터" });
+                .mockResolvedValue({
+                    id: "user-id",
+                    score: 200,
+                    nickname: "테스터",
+                });
         }),
     })
 );

--- a/app/api/member/arenas/[id]/join/__tests__/route.test.ts
+++ b/app/api/member/arenas/[id]/join/__tests__/route.test.ts
@@ -28,7 +28,7 @@ vi.mock(
         PrismaMemberRepository: vi.fn(function (this: Record<string, unknown>) {
             this.findById = vi
                 .fn()
-                .mockResolvedValue({ id: "user-id", score: 200 });
+                .mockResolvedValue({ id: "user-id", score: 200, nickname: "테스터" });
         }),
     })
 );
@@ -52,6 +52,33 @@ vi.mock("@/backend/arena/application/usecase/UpdateArenaStatusUsecase", () => ({
 
 vi.mock("@/lib/ArenaTimerRecovery", () => ({
     scheduleArenaTransitions: vi.fn(),
+}));
+
+vi.mock(
+    "@/backend/notification-record/infra/repositories/prisma/PrismaNotificationRecordRepository",
+    () => ({
+        PrismaNotificationRecordRepository: vi.fn(function (
+            this: Record<string, unknown>
+        ) {
+            this.save = vi.fn().mockResolvedValue(undefined);
+            this.count = vi.fn().mockResolvedValue(0);
+        }),
+    })
+);
+
+vi.mock(
+    "@/backend/notification-record/application/usecase/CreateNotificationRecordUsecase",
+    () => ({
+        CreateNotificationRecordUsecase: vi.fn(function (
+            this: Record<string, unknown>
+        ) {
+            this.execute = vi.fn().mockResolvedValue(undefined);
+        }),
+    })
+);
+
+vi.mock("@/lib/TierNotification", () => ({
+    sendTierNotificationIfChanged: vi.fn().mockResolvedValue(undefined),
 }));
 
 import { POST } from "../route";

--- a/app/api/member/arenas/[id]/join/route.ts
+++ b/app/api/member/arenas/[id]/join/route.ts
@@ -79,7 +79,9 @@ export async function POST(req: NextRequest, { params }: RequestParams) {
         // Notifications are non-critical — failure must not break the join response
         try {
             const notificationRepo = new PrismaNotificationRecordRepository();
-            const createNotification = new CreateNotificationRecordUsecase(notificationRepo);
+            const createNotification = new CreateNotificationRecordUsecase(
+                notificationRepo
+            );
             await createNotification.execute(
                 new CreateNotificationRecordDto(
                     arena.creatorId,
@@ -89,7 +91,11 @@ export async function POST(req: NextRequest, { params }: RequestParams) {
             );
             const updatedMember = await memberRepo.findById(memberId);
             if (updatedMember) {
-                await sendTierNotificationIfChanged(memberId, beforeScore, updatedMember.score);
+                await sendTierNotificationIfChanged(
+                    memberId,
+                    beforeScore,
+                    updatedMember.score
+                );
             }
         } catch (notificationErr) {
             log.warn({ err: notificationErr }, "참여 알림 생성 실패");

--- a/app/api/member/arenas/[id]/join/route.ts
+++ b/app/api/member/arenas/[id]/join/route.ts
@@ -10,6 +10,10 @@ import { ApplyArenaScoreUsecase } from "@/backend/score-policy/application/useca
 import { ScorePolicy } from "@/backend/score-policy/domain/ScorePolicy";
 import { PrismaScoreRecordRepository } from "@/backend/score-record/infra/repositories/prisma/PrismaScoreRecordRepository";
 import { scheduleArenaTransitions } from "@/lib/ArenaTimerRecovery";
+import { sendTierNotificationIfChanged } from "@/lib/TierNotification";
+import { PrismaNotificationRecordRepository } from "@/backend/notification-record/infra/repositories/prisma/PrismaNotificationRecordRepository";
+import { CreateNotificationRecordUsecase } from "@/backend/notification-record/application/usecase/CreateNotificationRecordUsecase";
+import { CreateNotificationRecordDto } from "@/backend/notification-record/application/usecase/dto/CreateNotificationRecordDto";
 import logger from "@/lib/Logger";
 
 type RequestParams = {
@@ -61,6 +65,7 @@ export async function POST(req: NextRequest, { params }: RequestParams) {
         );
 
         // challengerId comes from session — not from the request body
+        const beforeScore = member.score;
         await updateArenaStatusUsecase.execute(
             new UpdateArenaDetailDto(arenaId, 2, memberId)
         );
@@ -69,6 +74,25 @@ export async function POST(req: NextRequest, { params }: RequestParams) {
         const updatedArena = await arenaRepo.findById(arenaId);
         if (updatedArena) {
             scheduleArenaTransitions(updatedArena);
+        }
+
+        // Notifications are non-critical — failure must not break the join response
+        try {
+            const notificationRepo = new PrismaNotificationRecordRepository();
+            const createNotification = new CreateNotificationRecordUsecase(notificationRepo);
+            await createNotification.execute(
+                new CreateNotificationRecordDto(
+                    arena.creatorId,
+                    3,
+                    `${member.nickname}이(가) 투기장에 참여했습니다.`
+                )
+            );
+            const updatedMember = await memberRepo.findById(memberId);
+            if (updatedMember) {
+                await sendTierNotificationIfChanged(memberId, beforeScore, updatedMember.score);
+            }
+        } catch (notificationErr) {
+            log.warn({ err: notificationErr }, "참여 알림 생성 실패");
         }
 
         return NextResponse.json({ message: "참가 완료" }, { status: 200 });

--- a/app/api/member/arenas/[id]/join/route.ts
+++ b/app/api/member/arenas/[id]/join/route.ts
@@ -82,6 +82,7 @@ export async function POST(req: NextRequest, { params }: RequestParams) {
             const createNotification = new CreateNotificationRecordUsecase(
                 notificationRepo
             );
+            // typeId: 3=도전자 참가 (notification_types 테이블과 동기화 필요)
             await createNotification.execute(
                 new CreateNotificationRecordDto(
                     arena.creatorId,

--- a/app/api/member/attend/route.ts
+++ b/app/api/member/attend/route.ts
@@ -32,11 +32,18 @@ export async function POST() {
             if (memberBefore) {
                 const memberAfter = await memberRepo.findById(memberId);
                 if (memberAfter) {
-                    await sendTierNotificationIfChanged(memberId, memberBefore.score, memberAfter.score);
+                    await sendTierNotificationIfChanged(
+                        memberId,
+                        memberBefore.score,
+                        memberAfter.score
+                    );
                 }
             }
         } catch (notificationErr) {
-            log.warn({ userId: memberId, err: notificationErr }, "티어 알림 생성 실패");
+            log.warn(
+                { userId: memberId, err: notificationErr },
+                "티어 알림 생성 실패"
+            );
         }
 
         let attendedDateStr: string | null = null;

--- a/app/api/member/attend/route.ts
+++ b/app/api/member/attend/route.ts
@@ -5,6 +5,7 @@ import { PrismaScoreRecordRepository } from "@/backend/score-record/infra/reposi
 import { PrismaMemberRepository } from "@/backend/member/infra/repositories/prisma/PrismaMemberRepository";
 import { ScorePolicy } from "@/backend/score-policy/domain/ScorePolicy";
 import { errorResponse } from "@/utils/ApiResponse";
+import { sendTierNotificationIfChanged } from "@/lib/TierNotification";
 import logger from "@/lib/Logger";
 
 export async function POST() {
@@ -17,6 +18,7 @@ export async function POST() {
 
         const memberRepo = new PrismaMemberRepository();
         const lastAttendedDate = await memberRepo.getLastAttendedDate(memberId);
+        const memberBefore = await memberRepo.findById(memberId);
 
         const usecase = new ApplyAttendanceScoreUsecase(
             new ScorePolicy(),
@@ -25,6 +27,17 @@ export async function POST() {
         );
 
         await usecase.execute({ memberId, lastAttendedDate });
+
+        try {
+            if (memberBefore) {
+                const memberAfter = await memberRepo.findById(memberId);
+                if (memberAfter) {
+                    await sendTierNotificationIfChanged(memberId, memberBefore.score, memberAfter.score);
+                }
+            }
+        } catch (notificationErr) {
+            log.warn({ userId: memberId, err: notificationErr }, "티어 알림 생성 실패");
+        }
 
         let attendedDateStr: string | null = null;
         if (lastAttendedDate) {

--- a/app/api/member/notification-records/[id]/route.ts
+++ b/app/api/member/notification-records/[id]/route.ts
@@ -36,7 +36,7 @@ export async function PATCH(_req: Request, { params }: RequestParams) {
         if (record.memberId !== memberId) return errorResponse("권한이 없습니다.", 403);
 
         const usecase = new MarkNotificationReadUsecase(repository);
-        await usecase.execute(v.data);
+        await usecase.execute(record);
 
         return NextResponse.json({ message: "읽음 처리 완료" });
     } catch (error: unknown) {

--- a/app/api/member/notification-records/[id]/route.ts
+++ b/app/api/member/notification-records/[id]/route.ts
@@ -1,4 +1,5 @@
 import { DeleteNotificationRecordUsecase } from "@/backend/notification-record/application/usecase/DeleteNotificationRecordUsecase";
+import { MarkNotificationReadUsecase } from "@/backend/notification-record/application/usecase/MarkNotificationReadUsecase";
 import { NotificationRecordRepository } from "@/backend/notification-record/domain/repositories/NotificationRecordRepository";
 import { PrismaNotificationRecordRepository } from "@/backend/notification-record/infra/repositories/prisma/PrismaNotificationRecordRepository";
 import { NotificationRecord } from "@/prisma/generated";
@@ -13,6 +14,37 @@ type RequestParams = {
         id: string;
     }>;
 };
+
+export async function PATCH(_req: Request, { params }: RequestParams) {
+    const memberId = await getAuthUserId();
+    const log = logger.child({
+        route: "/api/member/notification-records/[id]",
+        method: "PATCH",
+    });
+
+    if (!memberId) return errorResponse("알림 읽음 처리 권한이 없습니다.", 401);
+
+    try {
+        const { id: idStr } = await params;
+        const v = validate(IdSchema, idStr);
+        if (!v.success) return v.response;
+
+        const repository: NotificationRecordRepository =
+            new PrismaNotificationRecordRepository();
+        const record: NotificationRecord | null = await repository.findById(v.data);
+        if (!record) return errorResponse("알림을 찾을 수 없습니다.", 404);
+        if (record.memberId !== memberId) return errorResponse("권한이 없습니다.", 403);
+
+        const usecase = new MarkNotificationReadUsecase(repository);
+        await usecase.execute(v.data);
+
+        return NextResponse.json({ message: "읽음 처리 완료" });
+    } catch (error: unknown) {
+        log.error({ userId: memberId, err: error }, "알림 읽음 처리 실패");
+        const message = error instanceof Error ? error.message : "알 수 없는 오류 발생";
+        return errorResponse(message, 500);
+    }
+}
 
 export async function DELETE(request: Request, { params }: RequestParams) {
     const memberId: string | null = await getAuthUserId();

--- a/app/api/member/notification-records/count/route.ts
+++ b/app/api/member/notification-records/count/route.ts
@@ -1,0 +1,28 @@
+import { GetUnreadNotificationCountUsecase } from "@/backend/notification-record/application/usecase/GetUnreadNotificationCountUsecase";
+import { PrismaNotificationRecordRepository } from "@/backend/notification-record/infra/repositories/prisma/PrismaNotificationRecordRepository";
+import { getAuthUserId } from "@/utils/GetAuthUserId.server";
+import { errorResponse } from "@/utils/ApiResponse";
+import { NextResponse } from "next/server";
+import logger from "@/lib/Logger";
+
+export async function GET() {
+    const memberId = await getAuthUserId();
+    const log = logger.child({
+        route: "/api/member/notification-records/count",
+        method: "GET",
+    });
+
+    if (!memberId) return errorResponse("알림 조회 권한이 없습니다.", 401);
+
+    try {
+        const repository = new PrismaNotificationRecordRepository();
+        const usecase = new GetUnreadNotificationCountUsecase(repository);
+        const count = await usecase.execute(memberId);
+
+        return NextResponse.json({ count });
+    } catch (error: unknown) {
+        log.error({ userId: memberId, err: error }, "미읽음 알림 수 조회 실패");
+        const message = error instanceof Error ? error.message : "알 수 없는 오류 발생";
+        return errorResponse(message, 500);
+    }
+}

--- a/app/api/member/review-likes/[reviewId]/route.ts
+++ b/app/api/member/review-likes/[reviewId]/route.ts
@@ -11,6 +11,7 @@ import { IdSchema, validate } from "@/utils/Validation";
 import { errorResponse } from "@/utils/ApiResponse";
 import logger from "@/lib/Logger";
 import { RateLimiter, rateLimitResponse } from "@/lib/RateLimiter";
+import { sendTierNotificationIfChanged } from "@/lib/TierNotification";
 
 const reviewLikeLimiter = new RateLimiter("review-like", 60_000, 30);
 
@@ -51,10 +52,31 @@ export async function POST(
             applyReviewScoreUsecase
         );
 
+        // Capture review author's score before toggle for tier change detection
+        const review = await reviewRepo.findById(parsedReviewId);
+        const authorBefore = review ? await memberRepo.findById(review.memberId) : null;
+
         const result = await usecase.execute({
             reviewId: parsedReviewId,
             memberId: userId,
         });
+
+        // Check if review author's tier changed (non-critical)
+        try {
+            if (review && authorBefore) {
+                const authorAfter = await memberRepo.findById(review.memberId);
+                if (authorAfter) {
+                    await sendTierNotificationIfChanged(
+                        review.memberId,
+                        authorBefore.score,
+                        authorAfter.score
+                    );
+                }
+            }
+        } catch (notificationErr) {
+            log.warn({ userId, err: notificationErr }, "티어 알림 생성 실패");
+        }
+
         return NextResponse.json(result);
     } catch (err: unknown) {
         log.error({ userId, err }, "리뷰 좋아요 토글 실패");

--- a/app/api/member/review-likes/[reviewId]/route.ts
+++ b/app/api/member/review-likes/[reviewId]/route.ts
@@ -54,7 +54,9 @@ export async function POST(
 
         // Capture review author's score before toggle for tier change detection
         const review = await reviewRepo.findById(parsedReviewId);
-        const authorBefore = review ? await memberRepo.findById(review.memberId) : null;
+        const authorBefore = review
+            ? await memberRepo.findById(review.memberId)
+            : null;
 
         const result = await usecase.execute({
             reviewId: parsedReviewId,

--- a/app/components/Header.tsx
+++ b/app/components/Header.tsx
@@ -7,8 +7,8 @@ import { signOut } from "next-auth/react";
 import Image from "next/image";
 import Cookies from "js-cookie";
 import { getAuthUserId } from "@/utils/GetAuthUserId.client";
-import useModalStore from "@/stores/ModalStore";
 import Button from "./Button";
+import NotificationBellButton from "./NotificationBellButton";
 import { Menu, User, X } from "lucide-react";
 
 type MenuLinkProps = {
@@ -109,24 +109,9 @@ export default function Header() {
                 {/* 오른쪽  */}
                 <div className="flex hidden flex-shrink-0 items-center space-x-8 sm:flex">
                     {isLoggedIn && (
-                        <button
-                            className="relative rounded-lg p-2 transition-colors hover:bg-white/20"
-                            aria-label="알림"
-                            onClick={() => {
-                                useModalStore
-                                    .getState()
-                                    .openModal("notification", null);
-                                setMenuOpen(false);
-                            }}
-                        >
-                            <Image
-                                src="/icons/bell.svg"
-                                alt=""
-                                width={24}
-                                height={24}
-                                className="text-white"
-                            />
-                        </button>
+                        <NotificationBellButton
+                            onOpen={() => setMenuOpen(false)}
+                        />
                     )}
                     {isLoggedIn ? (
                         <>
@@ -190,27 +175,10 @@ export default function Header() {
                             <>
                                 <div className="flex items-center space-x-4">
                                     {/* 알림 버튼 */}
-                                    <button
-                                        className="flex items-center justify-center rounded-lg p-2 transition-colors hover:bg-white/10"
-                                        aria-label="알림"
-                                        onClick={() => {
-                                            useModalStore
-                                                .getState()
-                                                .openModal(
-                                                    "notification",
-                                                    null
-                                                );
-                                            setMenuOpen(false);
-                                        }}
-                                    >
-                                        <Image
-                                            src="/icons/bell.svg"
-                                            alt=""
-                                            width={20}
-                                            height={20}
-                                            className="text-white"
-                                        />
-                                    </button>
+                                    <NotificationBellButton
+                                        size={20}
+                                        onOpen={() => setMenuOpen(false)}
+                                    />
 
                                     {/* 마이페이지 버튼 */}
                                     <Link

--- a/app/components/Header.tsx
+++ b/app/components/Header.tsx
@@ -107,7 +107,7 @@ export default function Header() {
                 </nav>
 
                 {/* 오른쪽  */}
-                <div className="flex hidden flex-shrink-0 items-center space-x-8 sm:flex">
+                <div className="hidden flex-shrink-0 items-center space-x-8 sm:flex">
                     {isLoggedIn && (
                         <NotificationBellButton
                             onOpen={() => setMenuOpen(false)}

--- a/app/components/ModalWrapper.tsx
+++ b/app/components/ModalWrapper.tsx
@@ -9,6 +9,7 @@ type ModalWrapperProps = {
     onClose: () => void;
     children: ReactNode;
     labelId?: string;
+    dialogClassName?: string;
 };
 
 export default function ModalWrapper({
@@ -16,6 +17,7 @@ export default function ModalWrapper({
     onClose,
     children,
     labelId,
+    dialogClassName = "max-w-[700px]",
 }: ModalWrapperProps) {
     useEffect(() => {
         if (!isOpen) return;
@@ -32,20 +34,21 @@ export default function ModalWrapper({
         <div
             className="fixed inset-0 z-[10001] flex items-center justify-center bg-black/50 px-2 sm:px-4" // z-[10001]: LottieLoader(z-[9999]) 위에 표시되도록
             onClick={onClose}
+            onKeyDown={(e) => e.key === "Escape" && onClose()}
         >
             <FocusTrap
                 active={isOpen}
                 focusTrapOptions={{
+                    returnFocusOnDeactivate: true,
                     escapeDeactivates: false,
                     allowOutsideClick: true,
-                    returnFocusOnDeactivate: true,
                 }}
             >
                 <div
                     role="dialog"
                     aria-modal="true"
                     aria-labelledby={labelId}
-                    className="max-h-[90vh] w-full max-w-[700px] overflow-y-auto rounded-xl bg-background-300 p-6 text-font-100 shadow-xl"
+                    className={`max-h-[90vh] w-full overflow-y-auto rounded-xl bg-background-300 p-6 text-font-100 shadow-xl ${dialogClassName}`}
                     onClick={(e) => e.stopPropagation()}
                 >
                     {children}

--- a/app/components/ModalWrapper.tsx
+++ b/app/components/ModalWrapper.tsx
@@ -48,6 +48,7 @@ export default function ModalWrapper({
                     role="dialog"
                     aria-modal="true"
                     aria-labelledby={labelId}
+                    onKeyDown={(e) => e.key === "Escape" && onClose()}
                     className={`max-h-[90vh] w-full overflow-y-auto rounded-xl bg-background-300 p-6 text-font-100 shadow-xl ${dialogClassName}`}
                     onClick={(e) => e.stopPropagation()}
                 >

--- a/app/components/NotificationBellButton.tsx
+++ b/app/components/NotificationBellButton.tsx
@@ -1,0 +1,41 @@
+"use client";
+
+import Image from "next/image";
+import useModalStore from "@/stores/ModalStore";
+import { useNotificationCount } from "@/hooks/useNotificationCount";
+
+type Props = {
+    size?: number;
+    onOpen?: () => void;
+};
+
+export default function NotificationBellButton({ size = 24, onOpen }: Props) {
+    const { data } = useNotificationCount();
+    const count = data?.count ?? 0;
+
+    const handleClick = () => {
+        useModalStore.getState().openModal("notification", null);
+        onOpen?.();
+    };
+
+    return (
+        <button
+            className="relative rounded-lg p-2 transition-colors hover:bg-white/20"
+            aria-label="알림"
+            onClick={handleClick}
+        >
+            <Image
+                src="/icons/bell.svg"
+                alt=""
+                width={size}
+                height={size}
+                className="text-white"
+            />
+            {count > 0 && (
+                <span className="absolute -right-1 -top-1 flex h-4 min-w-4 items-center justify-center rounded-full bg-red-500 px-1 text-[10px] font-bold text-white">
+                    {count > 99 ? "99+" : count}
+                </span>
+            )}
+        </button>
+    );
+}

--- a/app/components/NotificationBellButton.tsx
+++ b/app/components/NotificationBellButton.tsx
@@ -32,10 +32,10 @@ export default function NotificationBellButton({ size = 24, onOpen }: Props) {
                 className="text-white"
             />
             {count > 0 && (
-                <span className="absolute -right-1 -top-1 flex h-4 min-w-4 items-center justify-center rounded-full bg-red-500 px-1 text-[10px] font-bold text-white">
+                <span className="absolute -right-1 -top-1 flex h-4 min-w-4 items-center justify-center rounded-full bg-red-500 px-1 text-caption font-bold text-white">
                     {count > 99 ? "99+" : count}
                 </span>
-            )}
+)}
         </button>
     );
 }

--- a/app/components/__tests__/NotificationBellButton.test.tsx
+++ b/app/components/__tests__/NotificationBellButton.test.tsx
@@ -1,0 +1,56 @@
+// @vitest-environment jsdom
+import { describe, it, expect, vi } from "vitest";
+import { render, screen } from "@testing-library/react";
+import NotificationBellButton from "../NotificationBellButton";
+
+vi.mock("@/hooks/useNotificationCount", () => ({
+    useNotificationCount: vi.fn(),
+}));
+
+vi.mock("@/stores/ModalStore", () => ({
+    default: {
+        getState: () => ({ openModal: vi.fn() }),
+    },
+}));
+
+vi.mock("next/image", () => ({
+    default: (props: React.ImgHTMLAttributes<HTMLImageElement>) => (
+        // eslint-disable-next-line @next/next/no-img-element, jsx-a11y/alt-text
+        <img {...props} />
+    ),
+}));
+
+import { useNotificationCount } from "@/hooks/useNotificationCount";
+
+describe("NotificationBellButton", () => {
+    it("count가 0이면 뱃지를 렌더링하지 않는다", () => {
+        vi.mocked(useNotificationCount).mockReturnValue({
+            data: { count: 0 },
+        } as ReturnType<typeof useNotificationCount>);
+
+        render(<NotificationBellButton />);
+
+        expect(screen.getByRole("button", { name: "알림" })).toBeDefined();
+        expect(screen.queryByText(/^\d+$|^99\+$/)).toBeNull();
+    });
+
+    it("count가 양수이면 뱃지에 숫자를 표시한다", () => {
+        vi.mocked(useNotificationCount).mockReturnValue({
+            data: { count: 5 },
+        } as ReturnType<typeof useNotificationCount>);
+
+        render(<NotificationBellButton />);
+
+        expect(screen.getByText("5")).toBeDefined();
+    });
+
+    it("count가 99를 초과하면 '99+'를 표시한다", () => {
+        vi.mocked(useNotificationCount).mockReturnValue({
+            data: { count: 100 },
+        } as ReturnType<typeof useNotificationCount>);
+
+        render(<NotificationBellButton />);
+
+        expect(screen.getByText("99+")).toBeDefined();
+    });
+});

--- a/backend/notification-record/application/usecase/CreateNotificationRecordUsecase.ts
+++ b/backend/notification-record/application/usecase/CreateNotificationRecordUsecase.ts
@@ -19,8 +19,6 @@ export class CreateNotificationRecordUsecase {
             memberId: createNotificationRecordDto.memberId,
             typeId: createNotificationRecordDto.typeId,
             description: createNotificationRecordDto.description,
-            isRead: false,
-            createdAt: new Date(),
         };
 
         const newRecord = await this.notificationRecordRepository.save(record);

--- a/backend/notification-record/application/usecase/CreateNotificationRecordUsecase.ts
+++ b/backend/notification-record/application/usecase/CreateNotificationRecordUsecase.ts
@@ -19,6 +19,7 @@ export class CreateNotificationRecordUsecase {
             memberId: createNotificationRecordDto.memberId,
             typeId: createNotificationRecordDto.typeId,
             description: createNotificationRecordDto.description,
+            isRead: false,
             createdAt: new Date(),
         };
 

--- a/backend/notification-record/application/usecase/GetNotificationRecordUsecase.ts
+++ b/backend/notification-record/application/usecase/GetNotificationRecordUsecase.ts
@@ -33,6 +33,7 @@ export class GetNotificationRecordUsecase {
             memberId,
             null,
             null,
+            null,
             "createdAt",
             false,
             offset,
@@ -53,6 +54,7 @@ export class GetNotificationRecordUsecase {
                     memberId: record.memberId,
                     typeId: record.typeId,
                     description: record.description,
+                    isRead: record.isRead,
                     createdAt: record.createdAt,
                     typeName: type?.name || "기타",
                     typeImageUrl:

--- a/backend/notification-record/application/usecase/GetNotificationRecordUsecase.ts
+++ b/backend/notification-record/application/usecase/GetNotificationRecordUsecase.ts
@@ -2,7 +2,6 @@ import { NotificationTypeRepository } from "@/backend/notification-type/domain/r
 import { NotificationRecordRepository } from "@/backend/notification-record/domain/repositories/NotificationRecordRepository";
 import { GetNotificationRecordDto } from "./dto/GetNotificationRecordDto";
 import { NotificationRecordFilter } from "@/backend/notification-record/domain/repositories/filters/NotificationRecordFilter";
-import { NotificationRecord, NotificationType } from "@/prisma/generated";
 import { NotificationRecordListDto } from "./dto/NotificationRecordListDto";
 import { NotificationRecordDto } from "./dto/NotificationRecordDto";
 
@@ -40,30 +39,30 @@ export class GetNotificationRecordUsecase {
             limit
         );
 
-        const records: NotificationRecord[] =
-            await this.notificationRecordRepository.findAll(filter);
-        const recordDto: NotificationRecordDto[] = await Promise.all(
-            records.map(async (record) => {
-                const type: NotificationType | null =
-                    await this.notificationTypeRepository.findById(
-                        record.typeId
-                    );
+        const [records, totalCount, allTypes] = await Promise.all([
+            this.notificationRecordRepository.findAll(filter),
+            this.notificationRecordRepository.count(filter),
+            this.notificationTypeRepository.findAll(),
+        ]);
 
-                return {
-                    id: record.id,
-                    memberId: record.memberId,
-                    typeId: record.typeId,
-                    description: record.description,
-                    isRead: record.isRead,
-                    createdAt: record.createdAt,
-                    typeName: type?.name || "기타",
-                    typeImageUrl:
-                        type?.imageUrl || "@/public/icons/defaultTypeImage.ico",
-                };
-            })
+        const typeMap = new Map(allTypes.map((t) => [t.id, t]));
+
+        const recordDto: NotificationRecordDto[] = records.map(
+            (record) => {
+                const type = typeMap.get(record.typeId);
+                return new NotificationRecordDto(
+                    record.id,
+                    record.memberId,
+                    record.typeId,
+                    record.description,
+                    record.isRead,
+                    record.createdAt,
+                    type?.name ?? "기타",
+                    type?.imageUrl ?? "@/public/icons/defaultTypeImage.ico"
+                );
+            }
         );
-        const totalCount: number =
-            await this.notificationRecordRepository.count(filter);
+
         const startPage =
             Math.floor((currentPage - 1) / pageSize) * pageSize + 1;
         const endPage = Math.ceil(totalCount / pageSize);
@@ -71,14 +70,12 @@ export class GetNotificationRecordUsecase {
             (pageNumber) => pageNumber <= endPage
         );
 
-        const recordListDto: NotificationRecordListDto = {
-            records: recordDto,
+        return new NotificationRecordListDto(
+            recordDto,
             totalCount,
             currentPage,
             pages,
-            endPage,
-        };
-
-        return recordListDto;
+            endPage
+        );
     }
 }

--- a/backend/notification-record/application/usecase/GetNotificationRecordUsecase.ts
+++ b/backend/notification-record/application/usecase/GetNotificationRecordUsecase.ts
@@ -21,11 +21,11 @@ export class GetNotificationRecordUsecase {
         getNotificationRecordDto: GetNotificationRecordDto
     ): Promise<NotificationRecordListDto> {
         // page setup
-        const pageSize: number = 5;
+        const PAGE_SIZE = 5;
+        const PAGE_WINDOW = 5;
         const currentPage: number = getNotificationRecordDto.currentPage || 1;
         const memberId: string = getNotificationRecordDto.memberId;
-        const offset: number = (currentPage - 1) * pageSize;
-        const limit: number = pageSize;
+        const offset: number = (currentPage - 1) * PAGE_SIZE;
 
         // data query
         const filter = new NotificationRecordFilter(
@@ -36,7 +36,7 @@ export class GetNotificationRecordUsecase {
             "createdAt",
             false,
             offset,
-            limit
+            PAGE_SIZE
         );
 
         const [records, totalCount, allTypes] = await Promise.all([
@@ -47,28 +47,27 @@ export class GetNotificationRecordUsecase {
 
         const typeMap = new Map(allTypes.map((t) => [t.id, t]));
 
-        const recordDto: NotificationRecordDto[] = records.map(
-            (record) => {
-                const type = typeMap.get(record.typeId);
-                return new NotificationRecordDto(
-                    record.id,
-                    record.memberId,
-                    record.typeId,
-                    record.description,
-                    record.isRead,
-                    record.createdAt,
-                    type?.name ?? "기타",
-                    type?.imageUrl ?? "@/public/icons/defaultTypeImage.ico"
-                );
-            }
-        );
+        const recordDto: NotificationRecordDto[] = records.map((record) => {
+            const type = typeMap.get(record.typeId);
+            return new NotificationRecordDto(
+                record.id,
+                record.memberId,
+                record.typeId,
+                record.description,
+                record.isRead,
+                record.createdAt,
+                type?.name ?? "기타",
+                type?.imageUrl ?? "@/public/icons/defaultTypeImage.ico"
+            );
+        });
 
         const startPage =
-            Math.floor((currentPage - 1) / pageSize) * pageSize + 1;
-        const endPage = Math.ceil(totalCount / pageSize);
-        const pages = Array.from({ length: 5 }, (_, i) => i + startPage).filter(
-            (pageNumber) => pageNumber <= endPage
-        );
+            Math.floor((currentPage - 1) / PAGE_WINDOW) * PAGE_WINDOW + 1;
+        const endPage = Math.ceil(totalCount / PAGE_SIZE);
+        const pages = Array.from(
+            { length: PAGE_WINDOW },
+            (_, i) => i + startPage
+        ).filter((pageNumber) => pageNumber <= endPage);
 
         return new NotificationRecordListDto(
             recordDto,

--- a/backend/notification-record/application/usecase/GetUnreadNotificationCountUsecase.ts
+++ b/backend/notification-record/application/usecase/GetUnreadNotificationCountUsecase.ts
@@ -1,0 +1,18 @@
+import { NotificationRecordRepository } from "@/backend/notification-record/domain/repositories/NotificationRecordRepository";
+import { NotificationRecordFilter } from "@/backend/notification-record/domain/repositories/filters/NotificationRecordFilter";
+
+export class GetUnreadNotificationCountUsecase {
+    constructor(
+        private readonly notificationRecordRepository: NotificationRecordRepository
+    ) {}
+
+    async execute(memberId: string): Promise<number> {
+        const filter = new NotificationRecordFilter(
+            memberId,
+            null,
+            null,
+            false
+        );
+        return this.notificationRecordRepository.count(filter);
+    }
+}

--- a/backend/notification-record/application/usecase/MarkNotificationReadUsecase.ts
+++ b/backend/notification-record/application/usecase/MarkNotificationReadUsecase.ts
@@ -1,0 +1,13 @@
+import { NotificationRecordRepository } from "@/backend/notification-record/domain/repositories/NotificationRecordRepository";
+
+export class MarkNotificationReadUsecase {
+    constructor(
+        private readonly notificationRecordRepository: NotificationRecordRepository
+    ) {}
+
+    async execute(id: number): Promise<void> {
+        const record = await this.notificationRecordRepository.findById(id);
+        if (!record) throw new Error("알림을 찾을 수 없습니다.");
+        await this.notificationRecordRepository.update({ ...record, isRead: true });
+    }
+}

--- a/backend/notification-record/application/usecase/MarkNotificationReadUsecase.ts
+++ b/backend/notification-record/application/usecase/MarkNotificationReadUsecase.ts
@@ -1,3 +1,4 @@
+import { NotificationRecord } from "@/prisma/generated";
 import { NotificationRecordRepository } from "@/backend/notification-record/domain/repositories/NotificationRecordRepository";
 
 export class MarkNotificationReadUsecase {
@@ -5,9 +6,7 @@ export class MarkNotificationReadUsecase {
         private readonly notificationRecordRepository: NotificationRecordRepository
     ) {}
 
-    async execute(id: number): Promise<void> {
-        const record = await this.notificationRecordRepository.findById(id);
-        if (!record) throw new Error("알림을 찾을 수 없습니다.");
+    async execute(record: NotificationRecord): Promise<void> {
         await this.notificationRecordRepository.update({ ...record, isRead: true });
     }
 }

--- a/backend/notification-record/application/usecase/__tests__/GetUnreadNotificationCountUsecase.test.ts
+++ b/backend/notification-record/application/usecase/__tests__/GetUnreadNotificationCountUsecase.test.ts
@@ -1,0 +1,39 @@
+import { describe, it, expect, vi } from "vitest";
+import { GetUnreadNotificationCountUsecase } from "../GetUnreadNotificationCountUsecase";
+import { createMockNotificationRecordRepository } from "@/tests/mocks/createMockNotificationRecordRepository";
+import { NotificationRecordFilter } from "@/backend/notification-record/domain/repositories/filters/NotificationRecordFilter";
+
+describe("GetUnreadNotificationCountUsecase", () => {
+    it("미읽음 알림 3건 존재 시 3을 반환한다", async () => {
+        const repository = createMockNotificationRecordRepository();
+        vi.mocked(repository.count).mockResolvedValue(3);
+
+        const usecase = new GetUnreadNotificationCountUsecase(repository);
+        const result = await usecase.execute("member-1");
+
+        expect(result).toBe(3);
+    });
+
+    it("미읽음 알림 0건 시 0을 반환한다", async () => {
+        const repository = createMockNotificationRecordRepository();
+        vi.mocked(repository.count).mockResolvedValue(0);
+
+        const usecase = new GetUnreadNotificationCountUsecase(repository);
+        const result = await usecase.execute("member-1");
+
+        expect(result).toBe(0);
+    });
+
+    it("count 호출 시 filter의 isRead가 false임을 확인한다", async () => {
+        const repository = createMockNotificationRecordRepository();
+        vi.mocked(repository.count).mockResolvedValue(0);
+
+        const usecase = new GetUnreadNotificationCountUsecase(repository);
+        await usecase.execute("member-1");
+
+        const calledFilter = vi.mocked(repository.count).mock
+            .calls[0][0] as NotificationRecordFilter;
+        expect(calledFilter.isRead).toBe(false);
+        expect(calledFilter.memberId).toBe("member-1");
+    });
+});

--- a/backend/notification-record/application/usecase/__tests__/MarkNotificationReadUsecase.test.ts
+++ b/backend/notification-record/application/usecase/__tests__/MarkNotificationReadUsecase.test.ts
@@ -1,0 +1,34 @@
+import { describe, it, expect, vi } from "vitest";
+import { MarkNotificationReadUsecase } from "../MarkNotificationReadUsecase";
+import { createMockNotificationRecordRepository } from "@/tests/mocks/createMockNotificationRecordRepository";
+
+const mockRecord = {
+    id: 1,
+    memberId: "member-1",
+    typeId: 1,
+    description: "테스트 알림",
+    isRead: false,
+    createdAt: new Date(),
+};
+
+describe("MarkNotificationReadUsecase", () => {
+    it("레코드 존재 시 isRead: true로 update를 1회 호출한다", async () => {
+        const repository = createMockNotificationRecordRepository();
+        vi.mocked(repository.findById).mockResolvedValue(mockRecord);
+        vi.mocked(repository.update).mockResolvedValue({ ...mockRecord, isRead: true });
+
+        const usecase = new MarkNotificationReadUsecase(repository);
+        await usecase.execute(1);
+
+        expect(repository.update).toHaveBeenCalledTimes(1);
+        expect(repository.update).toHaveBeenCalledWith({ ...mockRecord, isRead: true });
+    });
+
+    it("알림이 없으면 Error를 throw한다", async () => {
+        const repository = createMockNotificationRecordRepository();
+        vi.mocked(repository.findById).mockResolvedValue(null);
+
+        const usecase = new MarkNotificationReadUsecase(repository);
+        await expect(usecase.execute(999)).rejects.toThrow("알림을 찾을 수 없습니다.");
+    });
+});

--- a/backend/notification-record/application/usecase/__tests__/MarkNotificationReadUsecase.test.ts
+++ b/backend/notification-record/application/usecase/__tests__/MarkNotificationReadUsecase.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi } from "vitest";
+import { describe, it, expect } from "vitest";
 import { MarkNotificationReadUsecase } from "../MarkNotificationReadUsecase";
 import { createMockNotificationRecordRepository } from "@/tests/mocks/createMockNotificationRecordRepository";
 
@@ -12,23 +12,13 @@ const mockRecord = {
 };
 
 describe("MarkNotificationReadUsecase", () => {
-    it("레코드 존재 시 isRead: true로 update를 1회 호출한다", async () => {
+    it("레코드를 isRead: true로 update를 1회 호출한다", async () => {
         const repository = createMockNotificationRecordRepository();
-        vi.mocked(repository.findById).mockResolvedValue(mockRecord);
-        vi.mocked(repository.update).mockResolvedValue({ ...mockRecord, isRead: true });
 
         const usecase = new MarkNotificationReadUsecase(repository);
-        await usecase.execute(1);
+        await usecase.execute(mockRecord);
 
         expect(repository.update).toHaveBeenCalledTimes(1);
         expect(repository.update).toHaveBeenCalledWith({ ...mockRecord, isRead: true });
-    });
-
-    it("알림이 없으면 Error를 throw한다", async () => {
-        const repository = createMockNotificationRecordRepository();
-        vi.mocked(repository.findById).mockResolvedValue(null);
-
-        const usecase = new MarkNotificationReadUsecase(repository);
-        await expect(usecase.execute(999)).rejects.toThrow("알림을 찾을 수 없습니다.");
     });
 });

--- a/backend/notification-record/application/usecase/dto/NotificationRecordDto.ts
+++ b/backend/notification-record/application/usecase/dto/NotificationRecordDto.ts
@@ -4,8 +4,8 @@ export class NotificationRecordDto {
         public memberId: string,
         public typeId: number,
         public description: string,
+        public isRead: boolean,
         public createdAt: Date,
-
         public typeName: string,
         public typeImageUrl: string
     ) {}

--- a/backend/notification-record/domain/repositories/NotificationRecordRepository.ts
+++ b/backend/notification-record/domain/repositories/NotificationRecordRepository.ts
@@ -1,7 +1,7 @@
 import { NotificationRecord } from "@/prisma/generated";
 import { NotificationRecordFilter } from "./filters/NotificationRecordFilter";
 
-export type CreateNotificationRecordInput = Omit<NotificationRecord, "id">;
+export type CreateNotificationRecordInput = Omit<NotificationRecord, "id" | "isRead" | "createdAt">;
 
 export interface NotificationRecordRepository {
     count(filter: NotificationRecordFilter): Promise<number>;

--- a/backend/notification-record/domain/repositories/filters/NotificationRecordFilter.ts
+++ b/backend/notification-record/domain/repositories/filters/NotificationRecordFilter.ts
@@ -3,6 +3,7 @@ export class NotificationRecordFilter {
         public memberId: string | null,
         public typeId: number | null,
         public createdAt: Date[] | null,
+        public isRead: boolean | null,
         public sortField: string = "createdAt",
         public ascending: boolean = false,
         public offset: number = 0,

--- a/backend/notification-record/infra/repositories/prisma/PrismaNotificationRecordRepository.ts
+++ b/backend/notification-record/infra/repositories/prisma/PrismaNotificationRecordRepository.ts
@@ -32,8 +32,8 @@ export class PrismaNotificationRecordRepository
                 createdAt.length > 0 && {
                     OR: createdAt.map((date) => ({
                         createdAt: {
-                            gte: new Date(date.setHours(0, 0, 0, 0)),
-                            lt: new Date(date.setHours(24, 0, 0, 0)),
+                            gte: new Date(new Date(date).setHours(0, 0, 0, 0)),
+                            lt: new Date(new Date(date).setHours(24, 0, 0, 0)),
                         },
                     })),
                 }),
@@ -87,9 +87,10 @@ export class PrismaNotificationRecordRepository
     }
 
     async update(record: NotificationRecord): Promise<NotificationRecord> {
+        const { id, memberId, typeId, description, isRead, createdAt } = record;
         const newData = await this.prisma.notificationRecord.update({
-            where: { id: record.id },
-            data: record,
+            where: { id },
+            data: { memberId, typeId, description, isRead, createdAt },
         });
 
         return newData;

--- a/backend/notification-record/infra/repositories/prisma/PrismaNotificationRecordRepository.ts
+++ b/backend/notification-record/infra/repositories/prisma/PrismaNotificationRecordRepository.ts
@@ -18,7 +18,7 @@ export class PrismaNotificationRecordRepository
     private getWhereClause(
         filter: NotificationRecordFilter
     ): Prisma.NotificationRecordWhereInput {
-        const { memberId, typeId, createdAt } = filter;
+        const { memberId, typeId, createdAt, isRead } = filter;
 
         return {
             ...(memberId && {
@@ -27,6 +27,7 @@ export class PrismaNotificationRecordRepository
             ...(typeId && {
                 typeId,
             }),
+            ...(isRead !== null && isRead !== undefined && { isRead }),
             ...(createdAt &&
                 createdAt.length > 0 && {
                     OR: createdAt.map((date) => ({

--- a/docs/ecc/plans/notification-read-state.md
+++ b/docs/ecc/plans/notification-read-state.md
@@ -1,0 +1,575 @@
+# Notification Read State Plan (Revised)
+
+알림 뱃지를 **미읽음 건수**로 전환하고, 알림 항목 클릭 시 읽음 처리 후 해당 페이지로 이동하는 계획.
+
+**개정 이유**: ECC 리뷰 반영 (B-1·H-2·M-1~M-5·L-1 수정) + isRead 동작 방식 변경
+- 구 동작: 모달 열기 → 전체 일괄 읽음 처리
+- 신 동작: 알림 항목 클릭 → 개별 읽음 처리 → 해당 페이지 이동 / 'x' 버튼 → 삭제
+
+**전제 조건 (B-1 인지)**: `NotificationBellButton.tsx` 및 5개 트리거 훅(P0/P1)이 먼저 병합되어야 함.
+이 계획은 P2 기능이므로 P0/P1 작업이 완료·병합된 이후에 실행할 것.
+
+---
+
+## Task 1 — DB 스키마: `isRead` 컬럼 추가
+
+**파일**: `prisma/schema.prisma`
+
+```prisma
+model NotificationRecord {
+  id          Int              @id @default(autoincrement())
+  memberId    String           @map("member_id")
+  typeId      Int              @map("type_id")
+  description String
+  isRead      Boolean          @default(false) @map("is_read")
+  createdAt   DateTime         @default(now()) @map("created_at")
+  member      Member           @relation(fields: [memberId], references: [id])
+  type        NotificationType @relation(fields: [typeId], references: [id])
+
+  @@map("notification_records")
+}
+```
+
+- `isRead`: 읽음 여부 (기본값 `false`)
+
+마이그레이션 실행:
+
+```bash
+npx prisma migrate dev --name add_notification_is_read
+npx prisma generate
+```
+
+---
+
+## Task 2 — Repository: `isRead` 필터 지원
+
+### 2a. `NotificationRecordFilter`에 `isRead` 추가
+
+**파일**: `backend/notification-record/domain/repositories/filters/NotificationRecordFilter.ts`
+
+```typescript
+export class NotificationRecordFilter {
+    constructor(
+        public memberId: string | null,
+        public typeId: number | null,
+        public createdAt: Date[] | null,
+        public isRead: boolean | null,      // ← 추가 (4번째 위치)
+        public sortField: string = "createdAt",
+        public ascending: boolean = false,
+        public offset: number = 0,
+        public limit: number = 5
+    ) {}
+}
+```
+
+**콜 사이트 전수 조사 (M-3 수정)**: `grep -r "new NotificationRecordFilter"` 결과 — 프로덕션 코드 콜 사이트 1개:
+
+| 파일 | 현재 인수 | 변경 후 인수 |
+|------|----------|-------------|
+| `backend/notification-record/application/usecase/GetNotificationRecordUsecase.ts:32` | `(memberId, null, null, "createdAt", false, offset, limit)` | `(memberId, null, null, null, "createdAt", false, offset, limit)` |
+
+### 2b. `NotificationRecordRepository` 인터페이스 — 변경 없음
+
+**파일**: `backend/notification-record/domain/repositories/NotificationRecordRepository.ts`
+
+`markAsRead`를 별도 메서드로 추가하지 않음.
+컨벤션(`BACKEND_ARCHITECTURE.md`): "partial field updates happen in usecase before calling `update()`".
+읽음 처리는 유스케이스에서 `record.isRead = true` 후 기존 `update(record)` 호출로 처리한다 (Task 5 참조).
+
+기존 인터페이스에서 추가·변경 없음:
+
+```typescript
+export interface NotificationRecordRepository {
+    count(filter: NotificationRecordFilter): Promise<number>;
+    findAll(filter: NotificationRecordFilter): Promise<NotificationRecord[]>;
+    findById(id: number): Promise<NotificationRecord | null>;
+    save(record: CreateNotificationRecordInput): Promise<NotificationRecord>;
+    update(record: NotificationRecord): Promise<NotificationRecord>;
+    deleteById(id: number): Promise<void>;
+}
+```
+
+### 2c. `PrismaNotificationRecordRepository` 구현 업데이트
+
+**파일**: `backend/notification-record/infra/repositories/prisma/PrismaNotificationRecordRepository.ts`
+
+`getWhereClause`에 `isRead` 조건 추가만 진행 (`markAsRead` 메서드 추가 없음):
+
+```typescript
+private getWhereClause(filter: NotificationRecordFilter): Prisma.NotificationRecordWhereInput {
+    const { memberId, typeId, createdAt, isRead } = filter;
+    return {
+        ...(memberId && { memberId }),
+        ...(typeId && { typeId }),
+        ...(isRead !== null && isRead !== undefined && { isRead }),
+        ...(createdAt && createdAt.length > 0 && {
+            OR: createdAt.map((date) => ({
+                createdAt: {
+                    gte: new Date(date.setHours(0, 0, 0, 0)),
+                    lt: new Date(date.setHours(24, 0, 0, 0)),
+                },
+            })),
+        }),
+    };
+}
+```
+
+---
+
+## Task 3 — DTO: `isRead` 필드 추가
+
+### 3a. `NotificationRecordDto`에 필드 추가
+
+**파일**: `backend/notification-record/application/usecase/dto/NotificationRecordDto.ts`
+
+```typescript
+export class NotificationRecordDto {
+    constructor(
+        public id: number,
+        public memberId: string,
+        public typeId: number,
+        public description: string,
+        public isRead: boolean,      // ← 추가
+        public createdAt: Date,
+        public typeName: string,
+        public typeImageUrl: string
+    ) {}
+}
+```
+
+### 3b. `GetNotificationRecordUsecase` 업데이트
+
+**파일**: `backend/notification-record/application/usecase/GetNotificationRecordUsecase.ts`
+
+`filter` 생성 (line 32) — `isRead: null` 삽입:
+
+```typescript
+// 변경 전
+const filter = new NotificationRecordFilter(
+    memberId,
+    null,
+    null,
+    "createdAt",
+    false,
+    offset,
+    limit
+);
+
+// 변경 후
+const filter = new NotificationRecordFilter(
+    memberId,
+    null,
+    null,
+    null,           // isRead: null — 전체 조회 (L-1: totalCount는 전체 건수 의미 유지)
+    "createdAt",
+    false,
+    offset,
+    limit
+);
+```
+
+> **L-1 주석**: `totalCount`는 이 변경 이후에도 "전체 알림 건수"를 의미함.
+> `NotificationModal` 페이지 계산이 totalCount에 의존하므로 `isRead: null`로 전체 조회 유지.
+> 미읽음 전용 카운트는 별도 Task 4 유스케이스 사용.
+
+`recordDto` 매핑에 `isRead` 추가:
+
+```typescript
+return {
+    id: record.id,
+    memberId: record.memberId,
+    typeId: record.typeId,
+    description: record.description,
+    isRead: record.isRead,           // ← 추가
+    createdAt: record.createdAt,
+    typeName: type?.name || "기타",
+    typeImageUrl: type?.imageUrl || "@/public/icons/defaultTypeImage.ico",
+};
+```
+
+---
+
+## Task 4 — 유스케이스: `GetUnreadNotificationCountUsecase` 신규 생성
+
+**신규 파일**: `backend/notification-record/application/usecase/GetUnreadNotificationCountUsecase.ts`
+
+```typescript
+import { NotificationRecordRepository } from "@/backend/notification-record/domain/repositories/NotificationRecordRepository";
+import { NotificationRecordFilter } from "@/backend/notification-record/domain/repositories/filters/NotificationRecordFilter";
+
+export class GetUnreadNotificationCountUsecase {
+    constructor(
+        private readonly notificationRecordRepository: NotificationRecordRepository
+    ) {}
+
+    async execute(memberId: string): Promise<number> {
+        const filter = new NotificationRecordFilter(
+            memberId,
+            null,
+            null,
+            false   // isRead: false → 미읽음만 카운트
+        );
+        return this.notificationRecordRepository.count(filter);
+    }
+}
+```
+
+---
+
+## Task 5 — 유스케이스: `MarkNotificationReadUsecase` 신규 생성
+
+**신규 파일**: `backend/notification-record/application/usecase/MarkNotificationReadUsecase.ts`
+
+개별 알림을 읽음 처리. 소유권 검증은 API 라우트에서 수행 (Task 6b).
+
+```typescript
+import { NotificationRecordRepository } from "@/backend/notification-record/domain/repositories/NotificationRecordRepository";
+
+export class MarkNotificationReadUsecase {
+    constructor(
+        private readonly notificationRecordRepository: NotificationRecordRepository
+    ) {}
+
+    async execute(id: number): Promise<void> {
+        const record = await this.notificationRecordRepository.findById(id);
+        if (!record) throw new Error("알림을 찾을 수 없습니다.");
+        await this.notificationRecordRepository.update({ ...record, isRead: true });
+    }
+}
+```
+
+---
+
+## Task 6 — API 라우트: 미읽음 카운트 + 개별 읽음 처리
+
+### 6a. `GET /api/member/notification-records/count`
+
+**신규 파일**: `app/api/member/notification-records/count/route.ts`
+
+```typescript
+import { GetUnreadNotificationCountUsecase } from "@/backend/notification-record/application/usecase/GetUnreadNotificationCountUsecase";
+import { PrismaNotificationRecordRepository } from "@/backend/notification-record/infra/repositories/prisma/PrismaNotificationRecordRepository";
+import { getAuthUserId } from "@/utils/GetAuthUserId.server";
+import { errorResponse } from "@/utils/ApiResponse";
+import { NextResponse } from "next/server";
+import logger from "@/lib/Logger";
+
+export async function GET() {
+    const memberId = await getAuthUserId();
+    const log = logger.child({
+        route: "/api/member/notification-records/count",
+        method: "GET",
+    });
+
+    if (!memberId) return errorResponse("알림 조회 권한이 없습니다.", 401);
+
+    try {
+        const repository = new PrismaNotificationRecordRepository();
+        const usecase = new GetUnreadNotificationCountUsecase(repository);
+        const count = await usecase.execute(memberId);
+
+        return NextResponse.json({ count });
+    } catch (error: unknown) {
+        log.error({ userId: memberId, err: error }, "미읽음 알림 수 조회 실패");
+        const message = error instanceof Error ? error.message : "알 수 없는 오류 발생";
+        return errorResponse(message, 500);
+    }
+}
+```
+
+### 6b. `PATCH /api/member/notification-records/[id]` — 개별 읽음 처리
+
+**신규 파일**: `app/api/member/notification-records/[id]/route.ts`
+
+> **M-1 해소**: 새 파일이므로 기존 GET 핸들러 스타일 충돌 없음. `errorResponse` 사용.
+
+```typescript
+import { MarkNotificationReadUsecase } from "@/backend/notification-record/application/usecase/MarkNotificationReadUsecase";
+import { PrismaNotificationRecordRepository } from "@/backend/notification-record/infra/repositories/prisma/PrismaNotificationRecordRepository";
+import { getAuthUserId } from "@/utils/GetAuthUserId.server";
+import { errorResponse } from "@/utils/ApiResponse";
+import { validate, IdSchema } from "@/utils/Validation";
+import { NextResponse } from "next/server";
+import logger from "@/lib/Logger";
+
+export async function PATCH(
+    _req: Request,
+    { params }: { params: Promise<{ id: string }> }
+) {
+    const memberId = await getAuthUserId();
+    const log = logger.child({
+        route: "/api/member/notification-records/[id]",
+        method: "PATCH",
+    });
+
+    if (!memberId) return errorResponse("알림 읽음 처리 권한이 없습니다.", 401);
+
+    try {
+        const { id: idStr } = await params;
+        const v = validate(IdSchema, idStr);
+        if (!v.success) return v.response;
+
+        const repository = new PrismaNotificationRecordRepository();
+        const record = await repository.findById(v.data);
+        if (!record) return errorResponse("알림을 찾을 수 없습니다.", 404);
+        if (record.memberId !== memberId) return errorResponse("권한이 없습니다.", 403);
+
+        const usecase = new MarkNotificationReadUsecase(repository);
+        await usecase.execute(v.data);
+
+        return NextResponse.json({ message: "읽음 처리 완료" });
+    } catch (error: unknown) {
+        log.error({ userId: memberId, err: error }, "알림 읽음 처리 실패");
+        const message = error instanceof Error ? error.message : "알 수 없는 오류 발생";
+        return errorResponse(message, 500);
+    }
+}
+```
+
+---
+
+## Task 7 — Frontend: `queryKeys` + `useNotificationCount` 훅
+
+### 7a. `queryKeys`에 `notificationCount` 추가
+
+**수정 파일**: `lib/QueryKeys.ts`
+
+```typescript
+/** Unread notification count for bell badge. */
+notificationCount: () => ["notificationCount"] as const,
+```
+
+### 7b. `useNotificationCount` 훅 신규 생성
+
+**신규 파일**: `hooks/useNotificationCount.ts`
+
+```typescript
+import { useQuery } from "@tanstack/react-query";
+import { fetcher } from "@/lib/Fetcher";
+import { queryKeys } from "@/lib/QueryKeys";
+
+export function useNotificationCount() {
+    return useQuery<{ count: number }>({
+        queryKey: queryKeys.notificationCount(),
+        queryFn: () => fetcher<{ count: number }>("/api/member/notification-records/count"),
+        refetchOnWindowFocus: false,
+    });
+}
+```
+
+### 7c. `NotificationBellButton` 업데이트
+
+**수정 파일**: `app/components/NotificationBellButton.tsx`
+
+- `useNotifications(1)` 제거 → `useNotificationCount()` 사용
+
+```typescript
+import { useNotificationCount } from "@/hooks/useNotificationCount";
+
+export default function NotificationBellButton({ size = 24, onOpen }: Props) {
+    const { data } = useNotificationCount();
+    const totalCount = data?.count ?? 0;
+    // 나머지 동일
+}
+```
+
+---
+
+## Task 8 — Frontend: 알림 클릭 시 읽음 처리 + 페이지 이동
+
+**수정 파일**: `app/(base)/components/NotificationRecordItem.tsx`
+
+알림 항목 클릭 시:
+1. `PATCH /api/member/notification-records/[id]` 호출 → 읽음 처리
+2. `notificationCount` 쿼리 무효화
+3. 이동 대상 URL은 호출부(소스)에서 직접 결정
+
+```typescript
+"use client";
+
+import { useMutation, useQueryClient } from "@tanstack/react-query";
+import { useRouter } from "next/navigation";
+import { queryKeys } from "@/lib/QueryKeys";
+
+type NotificationRecordItemProps = {
+    record: NotificationRecordDto;
+    href: string;
+};
+
+export default function NotificationRecordItem({ record, href }: NotificationRecordItemProps) {
+    const queryClient = useQueryClient();
+    const router = useRouter();
+
+    const { mutate: markRead } = useMutation({
+        mutationFn: () =>
+            fetch(`/api/member/notification-records/${record.id}`, { method: "PATCH" }),
+        onSuccess: () => {
+            // H-2 수정: 접두사 무효화로 전체 페이지 캐시 갱신
+            queryClient.invalidateQueries({ queryKey: queryKeys.notifications() });
+            queryClient.invalidateQueries({ queryKey: queryKeys.notificationCount() });
+            router.push(href);
+        },
+    });
+
+    const handleClick = () => {
+        if (!record.isRead) {
+            markRead();
+        } else {
+            router.push(href);
+        }
+    };
+
+    // 기존 삭제('x' 버튼) 로직 유지
+    // ...
+    return (
+        <div onClick={handleClick} style={{ opacity: record.isRead ? 0.6 : 1 }}>
+            {/* 기존 JSX */}
+        </div>
+    );
+}
+```
+
+> **H-2 수정**: 삭제 시 `queryKeys.notifications(1)` 단일 페이지 무효화 → `queryKeys.notifications()` 접두사 무효화로 변경.
+> 모든 페이지 캐시가 동시에 갱신됨.
+
+---
+
+## Task 9 — 삭제 시 카운트 무효화 (기존 Task 9 + H-2 수정)
+
+**수정 파일**: `app/(base)/components/NotificationRecordItem.tsx`
+
+기존 삭제 `onSuccess`에서:
+
+```typescript
+// 변경 전
+onSuccess: () => {
+    queryClient.invalidateQueries({
+        queryKey: queryKeys.notifications(1),  // page-1-only → 버그
+    });
+},
+
+// 변경 후 (H-2 수정)
+onSuccess: () => {
+    queryClient.invalidateQueries({
+        queryKey: queryKeys.notifications(),   // 접두사 무효화 → 전체 페이지
+    });
+    queryClient.invalidateQueries({
+        queryKey: queryKeys.notificationCount(),
+    });
+},
+```
+
+---
+
+## Task 10 — 테스트
+
+### 10a. Mock 파일 신규 생성 (M-5 수정)
+
+**신규 파일**: `tests/mocks/createMockNotificationRecordRepository.ts`
+
+프로젝트 컨벤션(`createMockArenaRepository.ts` 등) 따름:
+
+```typescript
+import { vi } from "vitest";
+import type { NotificationRecordRepository } from "@/backend/notification-record/domain/repositories/NotificationRecordRepository";
+
+export function createMockNotificationRecordRepository(): NotificationRecordRepository {
+    return {
+        count: vi.fn(),
+        findAll: vi.fn(),
+        findById: vi.fn(),
+        save: vi.fn(),
+        update: vi.fn(),
+        deleteById: vi.fn(),
+    };
+}
+```
+
+### 10b. `GetUnreadNotificationCountUsecase.test.ts`
+
+**신규 파일**: `backend/notification-record/application/usecase/__tests__/GetUnreadNotificationCountUsecase.test.ts`
+
+Mock: `createMockNotificationRecordRepository()` 사용.
+
+케이스:
+1. 미읽음 알림 3건 존재 시 `3` 반환
+2. 미읽음 알림 0건 시 `0` 반환
+3. `count()` 호출 시 filter의 `isRead`가 `false`임을 확인
+
+### 10c. `MarkNotificationReadUsecase.test.ts`
+
+**신규 파일**: `backend/notification-record/application/usecase/__tests__/MarkNotificationReadUsecase.test.ts`
+
+케이스:
+1. 레코드 존재 시 `update({ ...record, isRead: true })` 1회 호출 확인
+2. 알림 없음(`findById` → null) → Error throw 확인
+
+### 10d. `NotificationBellButton.test.tsx` 업데이트
+
+**수정 파일**: `app/components/__tests__/NotificationBellButton.test.tsx`
+
+- `vi.mock("@/hooks/useNotifications", ...)` → `vi.mock("@/hooks/useNotificationCount", ...)`
+- 기존 3케이스(뱃지 숨김·표시·99+) 유지, mock 모듈명만 변경
+
+---
+
+## 실행 순서
+
+```
+Task 1   DB 마이그레이션 (isRead 컬럼)                       — 선행 필수
+Task 2   Repository 인터페이스 + Filter + Prisma 구현        — Task 1 이후
+Task 3   DTO + GetNotificationRecordUsecase 업데이트         — Task 2 이후
+Task 4   GetUnreadNotificationCountUsecase 신규              — Task 2 이후
+Task 5   MarkNotificationReadUsecase 신규                    — Task 2 이후
+Task 6   API 라우트 (count + PATCH [id])                    — Task 4, 5 이후
+Task 7   queryKeys + useNotificationCount 훅                 — Task 6 이후
+Task 8   NotificationRecordItem 클릭 핸들러                  — Task 7 이후
+Task 9   NotificationRecordItem 삭제 무효화 수정              — Task 7 이후
+Task 10  Mock 파일 + 단위 테스트                             — Task 4, 5 이후
+```
+
+---
+
+## 신규/수정 파일 요약
+
+**신규 (7개)**
+- `prisma/migrations/<timestamp>_add_notification_is_read/migration.sql`
+- `app/api/member/notification-records/count/route.ts`
+- `app/api/member/notification-records/[id]/route.ts`
+- `backend/notification-record/application/usecase/GetUnreadNotificationCountUsecase.ts`
+- `backend/notification-record/application/usecase/MarkNotificationReadUsecase.ts`
+- `hooks/useNotificationCount.ts`
+- `tests/mocks/createMockNotificationRecordRepository.ts`
+
+**수정 (9개)**
+- `prisma/schema.prisma`
+- `backend/notification-record/domain/repositories/filters/NotificationRecordFilter.ts`
+- `backend/notification-record/domain/repositories/NotificationRecordRepository.ts`
+- `backend/notification-record/infra/repositories/prisma/PrismaNotificationRecordRepository.ts`
+- `backend/notification-record/application/usecase/dto/NotificationRecordDto.ts`
+- `backend/notification-record/application/usecase/GetNotificationRecordUsecase.ts`
+- `lib/QueryKeys.ts`
+- `app/components/NotificationBellButton.tsx`
+- `app/(base)/components/NotificationRecordItem.tsx`
+
+**테스트 신규/수정 (3개)**
+- `tests/mocks/createMockNotificationRecordRepository.ts` (Task 10a)
+- `backend/notification-record/application/usecase/__tests__/GetUnreadNotificationCountUsecase.test.ts`
+- `backend/notification-record/application/usecase/__tests__/MarkNotificationReadUsecase.test.ts`
+- `app/components/__tests__/NotificationBellButton.test.tsx`
+
+---
+
+## 리뷰 반영 체크리스트
+
+| 항목 | 상태 | 조치 |
+|------|------|------|
+| B-1 전제 조건 | ⚠️ 인지 | 계획 상단에 P0/P1 의존성 명시 |
+| H-1 useEffect deps | ✅ 해소 | 모달 일괄 읽음(Task 8 구)을 제거 — 해당 없음 |
+| H-2 page-1-only 무효화 | ✅ 수정 | `queryKeys.notifications()` 접두사 무효화로 변경 |
+| M-1 errorResponse 스타일 불일치 | ✅ 해소 | PATCH를 새 파일(`[id]/route.ts`)로 분리 — 충돌 없음 |
+| M-2 errorResponse import 누락 | ✅ 수정 | 6b 스니펫에 import 명시 |
+| M-3 Filter 콜 사이트 미감사 | ✅ 수정 | 프로덕션 1개 (`GetNotificationRecordUsecase.ts:32`) 명시 |
+| M-4 Usecase import 누락 | ✅ 수정 | 6b 스니펫에 import 명시 |
+| M-5 mock 파일 컨벤션 미준수 | ✅ 수정 | Task 10a에 `createMockNotificationRecordRepository.ts` 추가 |
+| L-1 totalCount 시맨틱 미문서화 | ✅ 수정 | Task 3b에 주석 추가 |

--- a/docs/ecc/reviews/feat-308-review.md
+++ b/docs/ecc/reviews/feat-308-review.md
@@ -1,0 +1,312 @@
+# PR Review: feat/#308 — 알림 읽음 상태 관리 및 P0/P1 알림 트리거
+
+**Reviewed**: 2026-04-25 (updated)
+**Branch**: feat/#308 → dev
+**Decision**: REQUEST CHANGES
+
+## Summary
+
+전반적으로 구조가 깔끔하고 Clean Architecture 패턴을 잘 따르고 있습니다. 비핵심 경로 분리(알림 실패 시 메인 흐름 불중단)도 적절합니다. 다만 `fetch()` 응답 오류 미처리 버그(HIGH)는 머지 전 반드시 수정이 필요합니다.
+
+---
+
+## Findings
+
+### CRITICAL
+없음.
+
+---
+
+### HIGH
+
+#### H1. `NotificationRecordItem.tsx` — `fetch()` 응답 오류 미처리
+**위치**: `app/(base)/components/NotificationRecordItem.tsx:32-52`
+
+`mutationFn`이 raw `fetch()` Promise를 반환합니다. TanStack Query는 Promise가 reject될 때만 에러로 처리하는데, `fetch()`는 4xx/5xx에서도 resolve됩니다. 따라서 PATCH/DELETE가 403 또는 500을 반환해도 `onSuccess`가 실행되어 캐시가 무효화되고 UI가 성공한 것처럼 동작합니다.
+
+```ts
+// 현재 (버그)
+mutationFn: () =>
+    fetch(`/api/member/notification-records/${notificationRecordDto.id}`, {
+        method: "PATCH",
+    }),
+
+// 수정 후
+mutationFn: async () => {
+    const res = await fetch(`/api/member/notification-records/${notificationRecordDto.id}`, {
+        method: "PATCH",
+    });
+    if (!res.ok) throw new Error((await res.json()).message ?? "요청 실패");
+},
+```
+
+DELETE `mutationFn`도 동일하게 수정 필요.
+
+---
+
+---
+
+### MEDIUM
+
+#### M0. `PrismaNotificationRecordRepository.update()` — 전체 레코드를 `data`에 전달
+**위치**: `backend/notification-record/infra/repositories/prisma/PrismaNotificationRecordRepository.ts:89-96`
+
+`data: record`로 `id`, `memberId`, `typeId`, `createdAt` 등 변경 불필요한 필드를 모두 Prisma `data`에 넘깁니다. 현재 `MarkNotificationReadUsecase`는 `{ ...record, isRead: true }`를 전달하므로 나머지 필드는 원래 값과 동일해 데이터 손상은 없습니다. 다만 Prisma가 생성하는 SQL에는 모든 컬럼이 SET 절에 포함되어 불필요한 쓰기가 발생하고, 훗날 `deletedAt` 등 새 필드가 추가될 때 이 패턴이 예상치 못한 값을 덮어쓸 수 있습니다.
+
+```ts
+// 수정 후: update input 타입을 명시적으로 제한
+async update(record: NotificationRecord): Promise<NotificationRecord> {
+    const { id, memberId, typeId, description, isRead, createdAt } = record;
+    const newData = await this.prisma.notificationRecord.update({
+        where: { id },
+        data: { memberId, typeId, description, isRead, createdAt },
+    });
+    return newData;
+}
+```
+
+또는 usecase에서 `isRead`만 변경하는 게 목적이라면 레포지토리에 `updateIsRead(id: number, isRead: boolean)` 메서드를 추가하는 것이 더 명확합니다.
+
+#### M1. N+1 쿼리 — `GetNotificationRecordUsecase`
+**위치**: `backend/notification-record/application/usecase/GetNotificationRecordUsecase.ts:45-64`
+
+페이지당 최대 5개 레코드에 대해 `notificationTypeRepository.findById()`를 개별 호출합니다. pageSize=5이므로 최대 5번의 추가 DB 쿼리가 발생합니다.
+
+`NotificationTypeRepository.findAll()`이 이미 존재하므로 이를 활용해 한 번에 조회하고 Map으로 룩업합니다:
+
+```ts
+// 수정 후 (1 쿼리)
+const allTypes = await this.notificationTypeRepository.findAll();
+const typeMap = new Map(allTypes.map((t) => [t.id, t]));
+
+const recordDto: NotificationRecordDto[] = records.map((record) => {
+    const type = typeMap.get(record.typeId);
+    return new NotificationRecordDto(
+        record.id, record.memberId, record.typeId,
+        record.description, record.isRead, record.createdAt,
+        type?.name ?? "기타",
+        type?.imageUrl ?? "@/public/icons/defaultTypeImage.ico"
+    );
+});
+```
+
+`async/await`도 제거되어 코드가 단순해집니다.
+
+---
+
+#### M2. 이중 DB 조회 — PATCH 핸들러와 `MarkNotificationReadUsecase`
+**위치**: `app/api/member/notification-records/[id]/route.ts:34` + `MarkNotificationReadUsecase.ts:9`
+
+라우트 핸들러에서 `findById`로 소유권 확인 후, `usecase.execute(id)`에서 다시 `findById`를 호출합니다. 동일 레코드에 대한 불필요한 DB 라운드트립입니다.
+
+권장 수정: 이미 조회한 레코드를 usecase에 직접 전달하도록 인터페이스 변경:
+```ts
+async execute(record: NotificationRecord): Promise<void>
+```
+
+---
+
+#### M3. 알림 typeId 매직 넘버
+**위치**: `lib/TierNotification.ts:15`, `lib/ArenaTimerRecovery.ts:185,205`
+
+typeId 1~5가 소스 전반에 하드코딩되어 있습니다. 별도 파일을 만들기보다 사용 위치에 인라인 주석을 추가해 typeId 변경 시 연동 수정이 필요함을 명시합니다.
+
+```ts
+// lib/TierNotification.ts
+// typeId: 1=티어 승급, 2=티어 강등 (notification_types 테이블과 동기화 필요)
+const typeId = afterScore > beforeScore ? 1 : 2;
+
+// lib/ArenaTimerRecovery.ts
+// typeId: 3=도전자 참가, 4=토론 시작, 5=투표 종료 (notification_types 테이블과 동기화 필요)
+await createNotification.execute(new CreateNotificationRecordDto(current.creatorId, 4, description));
+```
+
+---
+
+#### M4. Date 객체 뮤테이션 — `getWhereClause`
+**위치**: `backend/notification-record/infra/repositories/prisma/PrismaNotificationRecordRepository.ts:33-38`
+
+`date.setHours(0,0,0,0)`이 filter의 `createdAt` 배열 내 Date 객체를 직접 변경합니다. filter 객체가 재사용될 경우 버그를 유발합니다.
+
+```ts
+// 수정 후
+gte: new Date(new Date(date).setHours(0, 0, 0, 0)),
+lt: new Date(new Date(date).setHours(24, 0, 0, 0)),
+```
+
+---
+
+#### M5. 컴포넌트 테스트 부족
+`NotificationRecordItem`(읽음 처리 클릭, 삭제 버튼)과 `NotificationModal`(로딩 스켈레톤, 빈 상태, 페이지네이션)에 대한 테스트가 없습니다.
+
+---
+
+#### M6. CSS_STYLING.md 위반 — 임의 픽셀값 `text-[Xpx]` 사용
+**위치**: `app/components/NotificationBellButton.tsx:36`, `app/(base)/components/NotificationModal.tsx:36`
+
+규약: **"Never use raw `text-[Xpx]` — use named scale classes only."**
+
+두 곳에서 디자인 토큰 대신 임의 픽셀값을 사용합니다.
+
+| 파일 | 현재 | 권장 |
+|---|---|---|
+| `NotificationBellButton.tsx:36` | `text-[10px]` | `text-caption`(12px) 또는 `tailwind.config.ts`에 토큰 추가 |
+| `NotificationModal.tsx:36` | `text-[11px]` | 동일 |
+
+---
+
+#### M7. BACKEND_ARCHITECTURE.md 위반 — DTO 클래스 생성자 미사용
+**위치**: `backend/notification-record/application/usecase/GetNotificationRecordUsecase.ts:52-63, 74-80`
+
+규약: DTOs는 클래스로 정의되므로 `new Dto(...)` 생성자를 통해 인스턴스화해야 합니다. (참고: `return new ArenaDto(arena)` 패턴)
+
+`GetNotificationRecordUsecase`에서 `NotificationRecordDto`와 `NotificationRecordListDto` 모두 플레인 객체 리터럴로 생성됩니다.
+
+```ts
+// 현재 (위반)
+const recordListDto: NotificationRecordListDto = {
+    records: recordDto,
+    totalCount,
+    currentPage,
+    pages,
+    endPage,
+};
+
+// 수정 후
+return new NotificationRecordListDto(recordDto, totalCount, currentPage, pages, endPage);
+```
+
+`NotificationRecordDto`도 동일:
+```ts
+// 현재 (위반)
+return {
+    id: record.id,
+    memberId: record.memberId,
+    ...
+};
+
+// 수정 후
+return new NotificationRecordDto(
+    record.id, record.memberId, record.typeId,
+    record.description, record.isRead, record.createdAt,
+    type?.name ?? "기타",
+    type?.imageUrl ?? "@/public/icons/defaultTypeImage.ico"
+);
+```
+
+---
+
+### LOW
+
+#### L1. `ModalWrapper` — Escape 키 핸들러 미동작
+**위치**: `app/components/ModalWrapper.tsx:28`
+
+backdrop `div`의 `onKeyDown`은 해당 div에 포커스가 있을 때만 발생합니다. 그러나 `FocusTrap`이 내부 dialog에 포커스를 가두고, `escapeDeactivates: false`로 설정되어 FocusTrap의 자동 닫기도 비활성화됩니다. 결과적으로 키보드로 Escape를 눌러도 모달이 닫히지 않습니다.
+
+```tsx
+// 수정 후: inner dialog에 onKeyDown 추가
+<div
+    role="dialog"
+    aria-modal="true"
+    aria-labelledby={labelId}
+    onKeyDown={(e) => e.key === "Escape" && onClose()}
+    className={...}
+>
+```
+
+또는 FocusTrap의 `escapeDeactivates` 옵션을 활용:
+```tsx
+focusTrapOptions={{
+    returnFocusOnDeactivate: true,
+    escapeDeactivates: true,  // Escape로 FocusTrap 비활성화
+    onDeactivate: onClose,    // 비활성화 시 onClose 호출
+    allowOutsideClick: true,
+}}
+```
+
+---
+
+#### L2. `Header.tsx` — `flex hidden` 중복 클래스
+**위치**: `app/components/Header.tsx:110`
+
+`"flex hidden flex-shrink-0 items-center space-x-8 sm:flex"` — `hidden`이 `display: none`을 설정하므로 앞의 `flex`가 즉시 덮어씌워집니다. 선행 `flex`는 제거해도 동작에 차이가 없습니다.
+
+```tsx
+// 수정 후
+className="hidden flex-shrink-0 items-center space-x-8 sm:flex"
+```
+
+---
+
+#### L3. `useNotificationCount` staleTime 미설정
+**위치**: `hooks/useNotificationCount.ts`
+
+`staleTime`이 없어 컴포넌트 마운트마다 API 요청이 발생합니다. 벨 버튼 리렌더 시마다 불필요한 네트워크 비용이 생깁니다. `staleTime: 30_000` 정도 추가 권장.
+
+---
+
+#### L4. `CreateNotificationRecordUsecase` — DB 기본값 중복
+**위치**: `backend/notification-record/application/usecase/CreateNotificationRecordUsecase.ts:22-23`
+
+`isRead: false`와 `createdAt: new Date()`는 스키마 `@default(false)`, `@default(now())`와 중복입니다. 제거해도 동작에 차이 없습니다.
+
+---
+
+#### L5. `NotificationRecordDto` — 클래스지만 생성자 미사용 → M7로 격상
+**위치**: `backend/notification-record/application/usecase/dto/NotificationRecordDto.ts`
+
+`GetNotificationRecordUsecase`에서 `new NotificationRecordDto(...)` 대신 플레인 객체 리터럴로 생성합니다. 규약상 올바른 수정은 `type`으로 전환하는 것이 아니라 **생성자를 사용**하는 것입니다 — `NotificationRecordListDto`도 동일하게 위반하므로 **M7**에서 통합하여 다룹니다.
+
+---
+
+## Validation Results
+
+| Check | Result |
+|---|---|
+| TypeScript (`tsc --noEmit`) | Pass |
+| Lint (`npm run lint`) | Pass |
+| Tests (`npm test`) | Pass — 330 tests, 78 files |
+| Build | Skipped (pre-commit hook에서 검증) |
+
+_2회차 검증 (2026-04-25 최신 커밋 반영):_
+
+| Check | Result |
+|---|---|
+| TypeScript (`tsc --noEmit`) | Pass |
+| Lint (`npm run lint`) | Pass |
+| Tests (`npm test`) | Pass — 330 tests, 78 files |
+
+## Files Reviewed
+
+| File | Type |
+|---|---|
+| `prisma/schema.prisma` | Modified |
+| `prisma/migrations/20260423121931_add_notification_is_read/migration.sql` | Added |
+| `backend/notification-record/application/usecase/CreateNotificationRecordUsecase.ts` | Modified |
+| `backend/notification-record/application/usecase/GetNotificationRecordUsecase.ts` | Modified |
+| `backend/notification-record/application/usecase/GetUnreadNotificationCountUsecase.ts` | Added |
+| `backend/notification-record/application/usecase/MarkNotificationReadUsecase.ts` | Added |
+| `backend/notification-record/application/usecase/dto/NotificationRecordDto.ts` | Modified |
+| `backend/notification-record/domain/repositories/filters/NotificationRecordFilter.ts` | Modified |
+| `backend/notification-record/infra/repositories/prisma/PrismaNotificationRecordRepository.ts` | Modified |
+| `app/api/member/notification-records/[id]/route.ts` | Modified |
+| `app/api/member/notification-records/count/route.ts` | Added |
+| `app/api/member/arenas/[id]/join/route.ts` | Modified |
+| `app/api/member/attend/route.ts` | Modified |
+| `app/api/member/review-likes/[reviewId]/route.ts` | Modified |
+| `app/(base)/components/NotificationModal.tsx` | Modified |
+| `app/components/ModalWrapper.tsx` | Added |
+| `app/(base)/components/NotificationRecordList.tsx` | Modified |
+| `app/(base)/components/NotificationRecordItem.tsx` | Modified |
+| `app/components/Header.tsx` | Modified |
+| `app/components/NotificationBellButton.tsx` | Modified |
+| `app/components/__tests__/NotificationBellButton.test.tsx` | Added |
+| `hooks/useNotificationCount.ts` | Added |
+| `lib/QueryKeys.ts` | Modified |
+| `lib/TierNotification.ts` | Added |
+| `lib/ArenaTimerRecovery.ts` | Modified |
+| `lib/__tests__/ArenaTimerRecovery.test.ts` | Modified |
+| `tests/mocks/createMockNotificationRecordRepository.ts` | Added |
+| `backend/notification-record/application/usecase/__tests__/GetUnreadNotificationCountUsecase.test.ts` | Added |
+| `backend/notification-record/application/usecase/__tests__/MarkNotificationReadUsecase.test.ts` | Added |
+| `app/api/member/arenas/[id]/join/__tests__/route.test.ts` | Modified |

--- a/docs/pm-skills/notification-discovery.md
+++ b/docs/pm-skills/notification-discovery.md
@@ -1,0 +1,158 @@
+# Discovery Plan: Notification Feature
+
+**Date**: 2026-04-14
+**Product Stage**: Existing product (feature addition)
+**Discovery Question**: Which notification trigger events matter most to Gamechu users, and how should they be delivered?
+
+---
+
+## Codebase Context (What's Already Built)
+
+The notification infrastructure is scaffolded but not yet wired to any events:
+
+| Layer | Status |
+|-------|--------|
+| DB schema: `NotificationType` + `NotificationRecord` | ✅ Exists |
+| Backend: usecase / domain / infra layers | ✅ Exists |
+| API: `GET /api/member/notification-records` + `DELETE .../[id]` | ✅ Exists |
+| UI: `NotificationModal`, `NotificationRecordList`, `NotificationRecordItem` | ✅ Exists |
+| Hook: `useNotifications` | ✅ Exists |
+| Notification type seed data | ❌ Empty |
+| Any trigger that calls `CreateNotificationRecordUsecase` | ❌ None |
+| Unread count badge on bell icon | ❌ Missing |
+| Real-time delivery via Socket.IO | ❌ Not connected |
+
+---
+
+## Defined Notification Types
+
+These 5 types are confirmed and must be seeded into `NotificationType`:
+
+| # | Type Name | Trigger Event |
+|---|-----------|---------------|
+| 1 | **Tier Promote** | User's tier increases after score recalculation |
+| 2 | **Tier Relegation** | User's tier decreases after score recalculation |
+| 3 | **Arena Challenger Arrival** | A challenger joins the user's arena |
+| 4 | **Arena Start** | Arena status transitions to active (both players ready) |
+| 5 | **Arena Finished** | Arena ends (timer expiry or manual close) |
+
+---
+
+## Ideas Explored
+
+| # | Idea | Lens |
+|---|------|------|
+| 1 | Arena Challenger Arrival — notify arena owner when someone joins | PM |
+| 2 | Arena Start — notify both players when arena goes active | PM |
+| 3 | Arena Finished — notify both players when arena ends with result | PM |
+| 4 | Tier Promote / Relegation — notify user on tier change after scoring | PM |
+| 5 | Unread badge on bell icon — show count in header | Designer |
+| 6 | Real-time delivery via Socket.IO | Eng |
+| 7 | Notification preferences per user | PM |
+| 8 | Weekly digest email | PM |
+
+> **Excluded**: Review liked — high spam risk with low incremental value.
+
+---
+
+## Selected Ideas for Validation
+
+| # | Idea | Rationale |
+|---|------|-----------|
+| 1 | Arena Challenger Arrival | Highest urgency signal; owner must know a match started |
+| 2 | Arena Start | Both players need a clear "game on" signal |
+| 3 | Arena Finished | Closes the core game loop; drives return to check results |
+| 4 | Tier Promote / Relegation | High-emotion moments; strongest retention driver |
+| 5 | Unread badge | Usability prerequisite — users have no visual cue today |
+
+---
+
+## Critical Assumptions
+
+| # | Assumption | Category | Impact | Uncertainty | Priority |
+|---|-----------|----------|--------|-------------|----------|
+| A1 | Users don't discover the modal without a visible badge | Usability | High | High | P0 |
+| A2 | Arena join (`POST .../join`) is a single hook point for challenger arrival notification | Feasibility | High | High | P0 |
+| A3 | Arena end is a single deterministic event (timer or PATCH handler) | Feasibility | High | Medium | P1 |
+| A4 | Arena start has a single identifiable status-transition hook | Feasibility | High | Medium | P1 |
+| A5 | Tier change is computed in one place and produces a clear up/down delta | Feasibility | High | Medium | P1 |
+| A6 | In-app notifications are sufficient for MVP (no push/email needed yet) | Value | High | Low | P2 |
+
+---
+
+## Validation Experiments
+
+| # | Tests | Method | Success Criteria | Effort | Timeline |
+|---|-------|--------|-----------------|--------|----------|
+| E1 | A1 (badge usability) | Add `unreadCount` to GET response; render badge on bell icon | Modal open rate increases | 0.5 day | Week 1 |
+| E2 | A2 (challenger arrival hook) | Audit `POST /api/arenas/[id]/join` — trace all code paths | Single insertion point confirmed | 2h | Week 1 |
+| E3 | A3 (arena end hook) | Audit timer/end handler and any PATCH arena-status routes | Single deterministic end event confirmed | 2h | Week 1 |
+| E4 | A4 (arena start hook) | Audit status-transition to active — confirm single path | Single insertion point confirmed | 2h | Week 1 |
+| E5 | A5 (tier change hook) | Audit tier recalculation logic — confirm single up/down delta computation | Clear up/down delta at one code location | 2h | Week 1 |
+
+---
+
+## Experiment Details
+
+### E1 — Unread Badge
+- **Hypothesis**: Users open the notification modal more when a count badge is visible on the bell icon.
+- **Setup**: Extend GET response to include `unreadCount` (count of all records for the user). Add red badge to `Header.tsx` bell icon.
+- **Measurement**: Log modal open events; compare before vs. after badge.
+- **Decision**: Opens increase → badge is the right unlock. Flat → investigate discoverability further before adding more triggers.
+
+### E2 — Arena Challenger Arrival Hook
+- **Hypothesis**: `POST /api/arenas/[id]/join` has one clean exit path for inserting a notification to the arena owner.
+- **Setup**: Read `app/api/arenas/[id]/join/route.ts`; trace all code paths.
+- **Decision**: Single path → wire `CreateNotificationRecordUsecase` directly. Multiple paths → introduce a `NotificationService` called from all paths.
+
+### E3 — Arena Finished Hook
+- **Hypothesis**: Arena end is triggered at one deterministic place (timer expiry or manual close handler).
+- **Setup**: Trace arena status-update handlers, the timer chain, and any PATCH routes that set arena to ended state.
+- **Decision**: Single path → wire notification there. Multiple paths → identify canonical end event first.
+
+### E4 — Arena Start Hook
+- **Hypothesis**: The transition to "active" status happens in one place.
+- **Setup**: Search for arena status transition logic (e.g., status update when challenger joins and conditions are met).
+- **Decision**: Single path → wire notification. Multiple paths → centralize before wiring.
+
+### E5 — Tier Change Hook
+- **Hypothesis**: Tier recalculation produces a clear up/down delta at one code location.
+- **Setup**: Trace scoring / tier recalculation logic; look for where old tier vs. new tier are compared.
+- **Decision**: Single location with delta → wire Promote/Relegation notification based on sign. Scattered → aggregate first.
+
+---
+
+## Discovery Timeline
+
+| Week | Activity | Output |
+|------|----------|--------|
+| Week 1 | E2–E5 hook audits | Go/no-go decision on each trigger wiring |
+| Week 1 | Seed 5 `NotificationType` rows + icons | Modal renders typed items correctly |
+| Week 1–2 | E1 — unread badge shipped | Bell icon shows count; baseline established |
+| Week 2 | Wire Arena Challenger Arrival (#2) | First real notifications in prod |
+| Week 2 | Wire Arena Start (#3) | Players get "game on" signal |
+| Week 2 | Wire Arena Finished (#4) | Arena loop fully closed |
+| Week 3 | Wire Tier Promote / Relegation (#1, #5) | Highest-emotion notifications live |
+| Week 3 | Retrospective | Decide: real-time Socket.IO delivery or preferences UI next |
+
+---
+
+## Decision Framework
+
+- E2 single path → wire challenger arrival in `join/route.ts` directly
+- E2 multiple paths → introduce `NotificationService` wrapper first
+- E3 single end event → wire Arena Finished in timer/end handler
+- E4 single start transition → wire Arena Start at status flip
+- E5 clear delta → wire Tier Promote (delta > 0) / Relegation (delta < 0) at recalculation site
+- E1 badge causes no open-rate increase → run user interview before building more triggers
+- All Week 1 audits pass → proceed to implementation sprint
+
+---
+
+## Recommended Next Steps
+
+1. **Audit** all 4 hook points (E2–E5) — ~8h total
+2. **Seed** 5 `NotificationType` rows and confirm modal renders with icons
+3. **Ship** unread badge (E1) as immediate quick win
+4. **Wire** triggers in order: Challenger Arrival → Arena Start → Arena Finished → Tier changes
+5. After all 5 types live → evaluate real-time Socket.IO delivery

--- a/docs/pm-skills/notification-okrs.md
+++ b/docs/pm-skills/notification-okrs.md
@@ -1,0 +1,66 @@
+# Team OKRs: Gamechu Notification Feature — Q2 2026
+
+**Aligned to**: Improve user engagement and retention by closing product feedback loops
+
+---
+
+### Objective 1: Make users feel informed at every critical moment of their Gamechu journey
+
+| # | Key Result | Baseline | Target | Owner |
+|---|-----------|----------|--------|-------|
+| KR1 | Notification records created per completed arena lifecycle (both players) | 0 | 6 records (3 types × 2 players) | Dev |
+| KR2 | Notification records created per tier-change event | 0 | 1 record per affected user | Dev |
+| KR3 | All 5 `NotificationType` rows using SVG icons (no `.ico`) | 0 / 5 | 5 / 5 | Dev |
+
+---
+
+### Objective 2: Surface notifications so users actually discover them
+
+| # | Key Result | Baseline | Target | Owner |
+|---|-----------|----------|--------|-------|
+| KR1 | Unread badge visible on bell icon when records exist | Not implemented | Shipped and rendering correctly | Dev |
+| KR2 | Bell modal open rate (GET endpoint request rate per DAU) | Unknown (establish baseline in Week 1) | Measurable increase vs. pre-badge baseline by end of phase | Dev |
+| KR3 | Notification modal shows correct type icon + name for all 5 types | 0 / 5 renderable | 5 / 5 confirmed via manual QA | Dev |
+
+---
+
+### Objective 3: Ship a notification system that is correct, traceable, and safe to extend
+
+| # | Key Result | Baseline | Target | Owner |
+|---|-----------|----------|--------|-------|
+| KR1 | All trigger insertion points are single, isolated hook locations (no scattered calls) | 0 wired | 3 arena triggers in `transitionArena()` + 1 tier trigger in `ApplyArenaScoreUsecase` | Dev |
+| KR2 | Tier change detection covered by unit tests (before/after `getTier` comparison) | 0 tests | ≥2 tests: one promote case, one relegation case | Dev |
+| KR3 | No new notification-related API endpoint exposed publicly (creation is server-side only) | Secure (POST endpoint previously removed) | Remains secure after all wiring | Dev |
+
+---
+
+### Alignment Map
+
+```
+Product Goal: Close feedback loops → keep users engaged
+  └─ O1: Inform users at key moments
+       └─ KR1-3: All 5 trigger types fire correctly
+  └─ O2: Make notifications discoverable
+       └─ KR1-3: Badge + icons drive modal opens
+  └─ O3: Ship correctly, safely, extendably
+       └─ KR1-3: Single hook points, tested, secure
+```
+
+---
+
+### Scoring Guide
+
+| Score | Meaning |
+|-------|---------|
+| 0.0–0.3 | Significant miss — investigate root cause |
+| 0.4–0.6 | Progress made but fell short |
+| 0.7–0.9 | Well-calibrated stretch — target zone |
+| 1.0 | Nailed it or target wasn't ambitious enough |
+
+---
+
+### Check-in Cadence (adapted for solo dev)
+
+- **End of each phase**: Score KRs for that phase before moving to next
+- **End of Phase 2** (after all arena triggers): Deep review — are notifications firing correctly in staging?
+- **End of Phase 3** (after tier triggers): Full score, retrospective, feed into next feature decision (Socket.IO real-time vs. preferences UI)

--- a/docs/pm-skills/notification-prd.md
+++ b/docs/pm-skills/notification-prd.md
@@ -1,0 +1,194 @@
+# Product Requirements Document: In-App Notification System
+
+**Author**: Kwon Woojin
+**Date**: 2026-04-15
+**Status**: Draft → Ready for Implementation
+**Stakeholders**: Dev (solo)
+
+---
+
+### 1. Executive Summary
+
+Gamechu has a fully scaffolded notification infrastructure (DB schema, backend use cases, UI modal, API routes) but zero triggers are wired — no notification is ever created. This PRD specifies completing the system by updating the 5 confirmed notification type icons, adding an unread badge to the bell icon, and wiring each trigger so users are informed of high-signal moments: arena lifecycle milestones and tier changes.
+
+---
+
+### 2. Background & Context
+
+The notification UI and backend were built as part of an earlier sprint but never connected to real events. As a result:
+- The bell icon in the header opens an empty modal for every user.
+- Users have no in-product signal when they are promoted/relegated in tier, when a challenger joins their arena, when their arena starts, or when it finishes.
+- There is no unread count badge, so even if notifications existed, users would have no reason to open the modal.
+
+Discovery confirmed (see `docs/pm-skills/notification-discovery.md`):
+- 5 trigger types are finalized and already seeded in DB.
+- Review liked was excluded due to spam risk.
+- The notification infrastructure is complete; only icon assets, badge, and trigger wiring are missing.
+
+---
+
+### 3. Notification Types (DB — already seeded)
+
+| id | name (DB) | Trigger | DB icon (current) | Better icon (SVG) |
+|----|-----------|---------|-------------------|-------------------|
+| 1 | 티어 승급 | Tier promote | `/icons/Promote.ico` | `/icons/promotion.svg` |
+| 2 | 티어 강등 | Tier relegation | `/icons/Relegation.ico` | `/icons/relegation.svg` |
+| 3 | 투기장 도전자 참여 완료 | Challenger joins arena | `/icons/ArenaMatching.ico` | `/icons/recruitComplete.svg` |
+| 4 | 투기장 토론 시작 | Arena goes active (status 1→3) | `/icons/AranaStart.ico` ⚠️ typo | `/icons/debateStart.svg` |
+| 5 | 투기장 투표 완료 | Arena finishes (status→5) | `/icons/ArenaFinish.ico` | `/icons/voteComplete.svg` |
+
+**Action**: Run a DB migration to update `image_url` for all 5 types to the SVG paths. Fix the typo in type 4 (`AranaStart` → `ArenaStart`) while at it.
+
+---
+
+### 4. Objectives & Success Metrics
+
+**Goals**:
+1. Every user receives a notification for each of the 5 trigger events.
+2. The bell icon shows an unread count so users discover the modal.
+3. Notifications are visually differentiated by type using SVG icons.
+
+**Non-Goals**:
+- Email or browser push notifications — in-app only.
+- Notification preferences / opt-out toggles.
+- Real-time delivery via Socket.IO — TanStack Query polling is sufficient for MVP.
+- Review liked notification — excluded by design.
+- Read/unread state per record — unread count = total record count (no `isRead` field needed).
+
+**Success Metrics**:
+
+| Metric | Current | Target | Measurement |
+|--------|---------|--------|-------------|
+| Notification records created per arena lifecycle | 0 | 2 per participant per completed arena | DB count |
+| Bell modal open rate | Unknown baseline | Increases after badge ships | Request logs on GET endpoint |
+| Notification types with SVG icons | 0 / 5 | 5 / 5 | DB `image_url` check |
+
+---
+
+### 5. Target Users & Segments
+
+- **Arena hosts** — need Challenger Arrival and Arena Start signals.
+- **Arena challengers** — need Arena Start and Arena Finished signals.
+- **All ranked users** — need Tier Promote and Tier Relegation signals.
+
+---
+
+### 6. User Stories & Requirements
+
+**P0 — Must Have**
+
+| # | User Story | Acceptance Criteria |
+|---|-----------|---------------------|
+| 1 | As a user, I see an unread count badge on the bell icon | Badge shows `totalCount`; visible whenever records exist |
+| 2 | As an arena owner, I receive a notification when a challenger joins | `NotificationRecord` created for `arena.creatorId`; typeId = 3 |
+| 3 | As a participant, I receive a notification when my arena starts | `NotificationRecord` created for both players when status → 3; typeId = 4 |
+| 4 | As a participant, I receive a notification when my arena finishes | `NotificationRecord` created for both players when status → 5; typeId = 5 |
+| 5 | As a user, I receive a notification when my tier is promoted | `NotificationRecord` created when score delta causes tier upgrade; typeId = 1 |
+| 6 | As a user, I receive a notification when my tier is relegated | `NotificationRecord` created when score delta causes tier downgrade; typeId = 2 |
+| 7 | As a user, I see distinct SVG icons on each notification card | All 5 `imageUrl` values updated to `.svg` paths; icons render in `NotificationRecordItem` |
+
+**P1 — Should Have**
+
+| # | User Story | Acceptance Criteria |
+|---|-----------|---------------------|
+| 8 | Notification descriptions include the game/arena name | Description strings use arena game title, e.g. "○○ 투기장 토론이 시작되었습니다." |
+
+**P2 — Nice to Have / Future**
+
+| # | User Story | Acceptance Criteria |
+|---|-----------|---------------------|
+| 9 | Real-time badge update via Socket.IO | Bell count updates without page refresh |
+| 10 | Per-type notification preferences | User can toggle each type on/off |
+| 11 | Read/unread state | Badge clears on modal open; `isRead` field on `NotificationRecord` |
+
+---
+
+### 7. Solution Overview
+
+#### 7a. Icon migration
+Update all 5 `NotificationType.imageUrl` values in DB via Prisma migration or seed script.
+
+#### 7b. Unread badge
+
+`totalCount` is already returned by `GET /api/member/notification-records` (page 1).
+- Add a dedicated lightweight hook `useNotificationCount` that fetches page 1 and reads `totalCount`.
+- Or reuse the existing `useNotifications(1)` result and read `.totalCount` from the store/context.
+- Render badge on the bell icon in `Header.tsx` when `totalCount > 0`.
+
+> **Open Q4 resolution**: Use `totalCount` from the existing paginated endpoint (page 1 call) — no new endpoint needed. Evaluate if a dedicated `GET .../count` route is warranted after usage patterns emerge.
+
+#### 7c. Trigger wiring (all inside `ArenaTimerRecovery.ts → transitionArena`)
+
+The arena status machine lives entirely in `lib/ArenaTimerRecovery.ts`. All automatic status transitions go through `transitionArena()`. This is the single insertion point for arena notifications.
+
+**Status map:**
+```
+1 (Recruiting) → 2 (Challenger joined)  ← set by join/route.ts
+2 → 3 (Debate active)                   ← timer: startDate
+3 → 4 (Voting)                           ← timer: startDate + 30 min
+4 → 5 (Finished)                         ← timer: startDate + 30 min + 24 h
+```
+
+| Trigger | Where to add | Recipient(s) | typeId |
+|---------|-------------|--------------|--------|
+| Challenger Arrival | `UpdateArenaStatusUsecase.execute()`, `status === 2` branch — after `updateChallengerAndStatus` | `arena.creatorId` | 3 |
+| Arena Start | `transitionArena()` in `ArenaTimerRecovery.ts`, after `updateArenaStatusUsecase.execute()` when `newStatus === 3` | `arena.creatorId` + `arena.challengerId` | 4 |
+| Arena Finished | `transitionArena()`, after `endArenaUsecase.execute()` when `newStatus === 5` | `arena.creatorId` + `arena.challengerId` | 5 |
+
+#### 7d. Tier change detection
+
+`ApplyArenaScoreUsecase.execute()` calls `memberRepository.incrementScore(memberId, delta)` but does not know the member's current score or tier. To detect a tier change:
+
+1. **Before** `incrementScore`: fetch `member.score` → compute `oldTier = getTier(member.score)`
+2. **After** `incrementScore`: fetch updated `member.score` → compute `newTier = getTier(newScore)`
+3. If `oldTier.id !== newTier.id`:
+   - `newTier > oldTier` → create Tier Promote notification (typeId = 1)
+   - `newTier < oldTier` → create Tier Relegation notification (typeId = 2)
+
+`ApplyArenaScoreUsecase` already receives `memberRepository` — extend its interface to expose `findById` (or `getScore`) alongside `incrementScore`, and inject `NotificationRecordRepository` for the create call.
+
+#### 7e. Description strings (Korean)
+
+| typeId | Description template |
+|--------|---------------------|
+| 3 | `"[게임명] 투기장에 도전자가 참여했습니다."` |
+| 4 | `"[게임명] 투기장 토론이 시작되었습니다."` |
+| 5 | `"[게임명] 투기장 투표가 완료되었습니다."` |
+| 1 | `"티어가 [이전티어] → [신규티어]로 승급했습니다."` |
+| 2 | `"티어가 [이전티어] → [신규티어]로 강등되었습니다."` |
+
+---
+
+### 8. Open Questions
+
+All previously open questions are now resolved:
+
+| # | Question | Resolution |
+|---|----------|------------|
+| Q1 | Icon assets | 5 SVG equivalents exist in `public/icons/` — update DB `image_url` values |
+| Q2 | Arena active hook point | Single: `transitionArena()` in `ArenaTimerRecovery.ts` when `newStatus === 3` |
+| Q3 | Tier change hook | `ApplyArenaScoreUsecase` — compare `getTier()` before/after `incrementScore` |
+| Q4 | Unread count source | Use `totalCount` from existing paginated GET page-1 response; no new endpoint |
+
+---
+
+### 9. Timeline & Phasing
+
+**Phase 1 — Foundation (Day 1)**
+- [ ] DB migration: update all 5 `NotificationType.imageUrl` to SVG paths (fix typo in type 4)
+- [ ] Ship unread badge on bell icon using `totalCount` from existing endpoint
+
+**Phase 2 — Arena Triggers (Day 2–3)**
+- [ ] Wire Challenger Arrival in `UpdateArenaStatusUsecase` (`status === 2` branch)
+- [ ] Wire Arena Start in `transitionArena()` (`newStatus === 3`)
+- [ ] Wire Arena Finished in `transitionArena()` (`newStatus === 5`)
+- [ ] Manual QA: full arena lifecycle produces correct notifications for both players
+
+**Phase 3 — Tier Triggers (Day 4)**
+- [ ] Extend `ApplyArenaScoreUsecase` to detect tier change before/after `incrementScore`
+- [ ] Inject `NotificationRecordRepository` and `CreateNotificationRecordUsecase`
+- [ ] Manual QA: score change that crosses tier boundary creates correct notification
+
+**Phase 4 — Retrospective**
+- Review modal open rate after badge ships
+- Decide: Socket.IO real-time delivery vs. notification preferences vs. read/unread state

--- a/hooks/useNotificationCount.ts
+++ b/hooks/useNotificationCount.ts
@@ -6,6 +6,7 @@ export function useNotificationCount() {
     return useQuery<{ count: number }>({
         queryKey: queryKeys.notificationCount(),
         queryFn: () => fetcher<{ count: number }>("/api/member/notification-records/count"),
+        staleTime: 30_000,
         refetchOnWindowFocus: false,
     });
 }

--- a/hooks/useNotificationCount.ts
+++ b/hooks/useNotificationCount.ts
@@ -1,0 +1,11 @@
+import { useQuery } from "@tanstack/react-query";
+import { fetcher } from "@/lib/Fetcher";
+import { queryKeys } from "@/lib/QueryKeys";
+
+export function useNotificationCount() {
+    return useQuery<{ count: number }>({
+        queryKey: queryKeys.notificationCount(),
+        queryFn: () => fetcher<{ count: number }>("/api/member/notification-records/count"),
+        refetchOnWindowFocus: false,
+    });
+}

--- a/lib/ArenaTimerRecovery.ts
+++ b/lib/ArenaTimerRecovery.ts
@@ -136,7 +136,9 @@ async function transitionArena(
                     applyArenaScoreUsecase,
                     voteRepo
                 );
-                const beforeCreator = await memberRepo.findById(current.creatorId);
+                const beforeCreator = await memberRepo.findById(
+                    current.creatorId
+                );
                 const beforeChallenger = current.challengerId
                     ? await memberRepo.findById(current.challengerId)
                     : null;
@@ -145,7 +147,9 @@ async function transitionArena(
 
                 // Tier change notifications are non-critical — failure must not block the state machine
                 try {
-                    const afterCreator = await memberRepo.findById(current.creatorId);
+                    const afterCreator = await memberRepo.findById(
+                        current.creatorId
+                    );
                     if (beforeCreator && afterCreator) {
                         await sendTierNotificationIfChanged(
                             current.creatorId,
@@ -154,7 +158,9 @@ async function transitionArena(
                         );
                     }
                     if (current.challengerId && beforeChallenger) {
-                        const afterChallenger = await memberRepo.findById(current.challengerId);
+                        const afterChallenger = await memberRepo.findById(
+                            current.challengerId
+                        );
                         if (afterChallenger) {
                             await sendTierNotificationIfChanged(
                                 current.challengerId,
@@ -170,17 +176,28 @@ async function transitionArena(
 
             // Arena event notifications are non-critical — failure must not block the state machine
             try {
-                const notificationRepo = new PrismaNotificationRecordRepository();
-                const createNotification = new CreateNotificationRecordUsecase(notificationRepo);
+                const notificationRepo =
+                    new PrismaNotificationRecordRepository();
+                const createNotification = new CreateNotificationRecordUsecase(
+                    notificationRepo
+                );
 
                 if (newStatus === 3) {
                     const description = `'${current.title}' 투기장의 토론이 시작되었습니다.`;
                     await createNotification.execute(
-                        new CreateNotificationRecordDto(current.creatorId, 4, description)
+                        new CreateNotificationRecordDto(
+                            current.creatorId,
+                            4,
+                            description
+                        )
                     );
                     if (current.challengerId) {
                         await createNotification.execute(
-                            new CreateNotificationRecordDto(current.challengerId, 4, description)
+                            new CreateNotificationRecordDto(
+                                current.challengerId,
+                                4,
+                                description
+                            )
                         );
                     }
                 }
@@ -188,16 +205,27 @@ async function transitionArena(
                 if (newStatus === 5) {
                     const description = `'${current.title}' 투기장의 투표가 종료되었습니다.`;
                     await createNotification.execute(
-                        new CreateNotificationRecordDto(current.creatorId, 5, description)
+                        new CreateNotificationRecordDto(
+                            current.creatorId,
+                            5,
+                            description
+                        )
                     );
                     if (current.challengerId) {
                         await createNotification.execute(
-                            new CreateNotificationRecordDto(current.challengerId, 5, description)
+                            new CreateNotificationRecordDto(
+                                current.challengerId,
+                                5,
+                                description
+                            )
                         );
                     }
                 }
             } catch (notificationErr) {
-                log.warn({ arenaId, newStatus, err: notificationErr }, "알림 생성 실패");
+                log.warn(
+                    { arenaId, newStatus, err: notificationErr },
+                    "알림 생성 실패"
+                );
             }
         }
         await redis.del(arenaDetailKey(arenaId));

--- a/lib/ArenaTimerRecovery.ts
+++ b/lib/ArenaTimerRecovery.ts
@@ -9,6 +9,10 @@ import { ScorePolicy } from "@/backend/score-policy/domain/ScorePolicy";
 import { PrismaMemberRepository } from "@/backend/member/infra/repositories/prisma/PrismaMemberRepository";
 import { PrismaScoreRecordRepository } from "@/backend/score-record/infra/repositories/prisma/PrismaScoreRecordRepository";
 import { PrismaVoteRepository } from "@/backend/vote/infra/repositories/prisma/PrismaVoteRepository";
+import { PrismaNotificationRecordRepository } from "@/backend/notification-record/infra/repositories/prisma/PrismaNotificationRecordRepository";
+import { CreateNotificationRecordUsecase } from "@/backend/notification-record/application/usecase/CreateNotificationRecordUsecase";
+import { CreateNotificationRecordDto } from "@/backend/notification-record/application/usecase/dto/CreateNotificationRecordDto";
+import { sendTierNotificationIfChanged } from "@/lib/TierNotification";
 import type { Arena } from "@/prisma/generated";
 import type { ArenaStatus } from "@/types/arena-status";
 import redis from "@/lib/Redis";
@@ -124,6 +128,7 @@ async function transitionArena(
             await updateArenaStatusUsecase.execute(
                 new UpdateArenaDetailDto(arenaId, newStatus)
             );
+
             if (newStatus === 5) {
                 const voteRepo = new PrismaVoteRepository();
                 const endArenaUsecase = new EndArenaUsecase(
@@ -131,7 +136,68 @@ async function transitionArena(
                     applyArenaScoreUsecase,
                     voteRepo
                 );
+                const beforeCreator = await memberRepo.findById(current.creatorId);
+                const beforeChallenger = current.challengerId
+                    ? await memberRepo.findById(current.challengerId)
+                    : null;
+
                 await endArenaUsecase.execute(arenaId);
+
+                // Tier change notifications are non-critical — failure must not block the state machine
+                try {
+                    const afterCreator = await memberRepo.findById(current.creatorId);
+                    if (beforeCreator && afterCreator) {
+                        await sendTierNotificationIfChanged(
+                            current.creatorId,
+                            beforeCreator.score,
+                            afterCreator.score
+                        );
+                    }
+                    if (current.challengerId && beforeChallenger) {
+                        const afterChallenger = await memberRepo.findById(current.challengerId);
+                        if (afterChallenger) {
+                            await sendTierNotificationIfChanged(
+                                current.challengerId,
+                                beforeChallenger.score,
+                                afterChallenger.score
+                            );
+                        }
+                    }
+                } catch (tierErr) {
+                    log.warn({ arenaId, err: tierErr }, "티어 알림 생성 실패");
+                }
+            }
+
+            // Arena event notifications are non-critical — failure must not block the state machine
+            try {
+                const notificationRepo = new PrismaNotificationRecordRepository();
+                const createNotification = new CreateNotificationRecordUsecase(notificationRepo);
+
+                if (newStatus === 3) {
+                    const description = `'${current.title}' 투기장의 토론이 시작되었습니다.`;
+                    await createNotification.execute(
+                        new CreateNotificationRecordDto(current.creatorId, 4, description)
+                    );
+                    if (current.challengerId) {
+                        await createNotification.execute(
+                            new CreateNotificationRecordDto(current.challengerId, 4, description)
+                        );
+                    }
+                }
+
+                if (newStatus === 5) {
+                    const description = `'${current.title}' 투기장의 투표가 종료되었습니다.`;
+                    await createNotification.execute(
+                        new CreateNotificationRecordDto(current.creatorId, 5, description)
+                    );
+                    if (current.challengerId) {
+                        await createNotification.execute(
+                            new CreateNotificationRecordDto(current.challengerId, 5, description)
+                        );
+                    }
+                }
+            } catch (notificationErr) {
+                log.warn({ arenaId, newStatus, err: notificationErr }, "알림 생성 실패");
             }
         }
         await redis.del(arenaDetailKey(arenaId));

--- a/lib/ArenaTimerRecovery.ts
+++ b/lib/ArenaTimerRecovery.ts
@@ -182,6 +182,7 @@ async function transitionArena(
                     notificationRepo
                 );
 
+                // typeId: 3=도전자 참가, 4=토론 시작, 5=투표 종료 (notification_types 테이블과 동기화 필요)
                 if (newStatus === 3) {
                     const description = `'${current.title}' 투기장의 토론이 시작되었습니다.`;
                     await createNotification.execute(

--- a/lib/QueryKeys.ts
+++ b/lib/QueryKeys.ts
@@ -116,7 +116,13 @@ export const queryKeys = {
     /**
      * Paginated notification records.
      * Param name is currentPage (matches /api/member/notification-records route).
+     * Call with no argument for prefix invalidation (invalidates all pages).
      */
-    notifications: (currentPage: number) =>
-        ["notifications", currentPage] as const,
+    notifications: (currentPage?: number) =>
+        currentPage !== undefined
+            ? (["notifications", currentPage] as const)
+            : (["notifications"] as const),
+
+    /** Unread notification count for bell badge. */
+    notificationCount: () => ["notificationCount"] as const,
 };

--- a/lib/TierNotification.ts
+++ b/lib/TierNotification.ts
@@ -20,5 +20,7 @@ export async function sendTierNotificationIfChanged(
 
     const repo = new PrismaNotificationRecordRepository();
     const usecase = new CreateNotificationRecordUsecase(repo);
-    await usecase.execute(new CreateNotificationRecordDto(memberId, typeId, description));
+    await usecase.execute(
+        new CreateNotificationRecordDto(memberId, typeId, description)
+    );
 }

--- a/lib/TierNotification.ts
+++ b/lib/TierNotification.ts
@@ -12,6 +12,7 @@ export async function sendTierNotificationIfChanged(
     const afterTier = getTier(afterScore);
     if (beforeTier.label === afterTier.label) return;
 
+    // typeId: 1=티어 승급, 2=티어 강등 (notification_types 테이블과 동기화 필요)
     const typeId = afterScore > beforeScore ? 1 : 2;
     const description =
         typeId === 1

--- a/lib/TierNotification.ts
+++ b/lib/TierNotification.ts
@@ -1,0 +1,24 @@
+import { getTier } from "@/utils/GetTiers";
+import { PrismaNotificationRecordRepository } from "@/backend/notification-record/infra/repositories/prisma/PrismaNotificationRecordRepository";
+import { CreateNotificationRecordUsecase } from "@/backend/notification-record/application/usecase/CreateNotificationRecordUsecase";
+import { CreateNotificationRecordDto } from "@/backend/notification-record/application/usecase/dto/CreateNotificationRecordDto";
+
+export async function sendTierNotificationIfChanged(
+    memberId: string,
+    beforeScore: number,
+    afterScore: number
+): Promise<void> {
+    const beforeTier = getTier(beforeScore);
+    const afterTier = getTier(afterScore);
+    if (beforeTier.label === afterTier.label) return;
+
+    const typeId = afterScore > beforeScore ? 1 : 2;
+    const description =
+        typeId === 1
+            ? `${afterTier.label} 티어로 승급했습니다!`
+            : `${afterTier.label} 티어로 강등되었습니다.`;
+
+    const repo = new PrismaNotificationRecordRepository();
+    const usecase = new CreateNotificationRecordUsecase(repo);
+    await usecase.execute(new CreateNotificationRecordDto(memberId, typeId, description));
+}

--- a/lib/__tests__/ArenaTimerRecovery.test.ts
+++ b/lib/__tests__/ArenaTimerRecovery.test.ts
@@ -95,6 +95,33 @@ vi.mock(
     })
 );
 
+vi.mock(
+    "@/backend/notification-record/infra/repositories/prisma/PrismaNotificationRecordRepository",
+    () => ({
+        PrismaNotificationRecordRepository: vi.fn(function (
+            this: Record<string, unknown>
+        ) {
+            this.save = vi.fn().mockResolvedValue(undefined);
+            this.count = vi.fn().mockResolvedValue(0);
+        }),
+    })
+);
+
+vi.mock(
+    "@/backend/notification-record/application/usecase/CreateNotificationRecordUsecase",
+    () => ({
+        CreateNotificationRecordUsecase: vi.fn(function (
+            this: Record<string, unknown>
+        ) {
+            this.execute = vi.fn().mockResolvedValue(undefined);
+        }),
+    })
+);
+
+vi.mock("@/lib/TierNotification", () => ({
+    sendTierNotificationIfChanged: vi.fn().mockResolvedValue(undefined),
+}));
+
 import { scheduleArenaTransitions } from "../ArenaTimerRecovery";
 
 // Each test uses a unique arenaId to avoid scheduledTimers Map interference

--- a/package-lock.json
+++ b/package-lock.json
@@ -1898,9 +1898,9 @@
             }
         },
         "node_modules/@next/env": {
-            "version": "15.5.14",
-            "resolved": "https://registry.npmjs.org/@next/env/-/env-15.5.14.tgz",
-            "integrity": "sha512-aXeirLYuASxEgi4X4WhfXsShCFxWDfNn/8ZeC5YXAS2BB4A8FJi1kwwGL6nvMVboE7fZCzmJPNdMvVHc8JpaiA==",
+            "version": "15.5.15",
+            "resolved": "https://registry.npmjs.org/@next/env/-/env-15.5.15.tgz",
+            "integrity": "sha512-vcmyu5/MyFzN7CdqRHO3uHO44p/QPCZkuTUXroeUmhNP8bL5PHFEhik22JUazt+CDDoD6EpBYRCaS2pISL+/hg==",
             "license": "MIT"
         },
         "node_modules/@next/eslint-plugin-next": {
@@ -1913,9 +1913,9 @@
             }
         },
         "node_modules/@next/swc-darwin-arm64": {
-            "version": "15.5.14",
-            "resolved": "https://registry.npmjs.org/@next/swc-darwin-arm64/-/swc-darwin-arm64-15.5.14.tgz",
-            "integrity": "sha512-Y9K6SPzobnZvrRDPO2s0grgzC+Egf0CqfbdvYmQVaztV890zicw8Z8+4Vqw8oPck8r1TjUHxVh8299Cg4TrxXg==",
+            "version": "15.5.15",
+            "resolved": "https://registry.npmjs.org/@next/swc-darwin-arm64/-/swc-darwin-arm64-15.5.15.tgz",
+            "integrity": "sha512-6PvFO2Tzt10GFK2Ro9tAVEtacMqRmTarYMFKAnV2vYMdwWc73xzmDQyAV7SwEdMhzmiRoo7+m88DuiXlJlGeaw==",
             "cpu": [
                 "arm64"
             ],
@@ -1929,9 +1929,9 @@
             }
         },
         "node_modules/@next/swc-darwin-x64": {
-            "version": "15.5.14",
-            "resolved": "https://registry.npmjs.org/@next/swc-darwin-x64/-/swc-darwin-x64-15.5.14.tgz",
-            "integrity": "sha512-aNnkSMjSFRTOmkd7qoNI2/rETQm/vKD6c/Ac9BZGa9CtoOzy3c2njgz7LvebQJ8iPxdeTuGnAjagyis8a9ifBw==",
+            "version": "15.5.15",
+            "resolved": "https://registry.npmjs.org/@next/swc-darwin-x64/-/swc-darwin-x64-15.5.15.tgz",
+            "integrity": "sha512-G+YNV+z6FDZTp/+IdGyIMFqalBTaQSnvAA+X/hrt+eaTRFSznRMz9K7rTmzvM6tDmKegNtyzgufZW0HwVzEqaQ==",
             "cpu": [
                 "x64"
             ],
@@ -1945,9 +1945,9 @@
             }
         },
         "node_modules/@next/swc-linux-arm64-gnu": {
-            "version": "15.5.14",
-            "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-gnu/-/swc-linux-arm64-gnu-15.5.14.tgz",
-            "integrity": "sha512-tjlpia+yStPRS//6sdmlVwuO1Rioern4u2onafa5n+h2hCS9MAvMXqpVbSrjgiEOoCs0nJy7oPOmWgtRRNSM5Q==",
+            "version": "15.5.15",
+            "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-gnu/-/swc-linux-arm64-gnu-15.5.15.tgz",
+            "integrity": "sha512-eVkrMcVIBqGfXB+QUC7jjZ94Z6uX/dNStbQFabewAnk13Uy18Igd1YZ/GtPRzdhtm7QwC0e6o7zOQecul4iC1w==",
             "cpu": [
                 "arm64"
             ],
@@ -1961,9 +1961,9 @@
             }
         },
         "node_modules/@next/swc-linux-arm64-musl": {
-            "version": "15.5.14",
-            "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-musl/-/swc-linux-arm64-musl-15.5.14.tgz",
-            "integrity": "sha512-8B8cngBaLadl5lbDRdxGCP1Lef8ipD6KlxS3v0ElDAGil6lafrAM3B258p1KJOglInCVFUjk751IXMr2ixeQOQ==",
+            "version": "15.5.15",
+            "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-musl/-/swc-linux-arm64-musl-15.5.15.tgz",
+            "integrity": "sha512-RwSHKMQ7InLy5GfkY2/n5PcFycKA08qI1VST78n09nN36nUPqCvGSMiLXlfUmzmpQpF6XeBYP2KRWHi0UW3uNg==",
             "cpu": [
                 "arm64"
             ],
@@ -1977,9 +1977,9 @@
             }
         },
         "node_modules/@next/swc-linux-x64-gnu": {
-            "version": "15.5.14",
-            "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-gnu/-/swc-linux-x64-gnu-15.5.14.tgz",
-            "integrity": "sha512-bAS6tIAg8u4Gn3Nz7fCPpSoKAexEt2d5vn1mzokcqdqyov6ZJ6gu6GdF9l8ORFrBuRHgv3go/RfzYz5BkZ6YSQ==",
+            "version": "15.5.15",
+            "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-gnu/-/swc-linux-x64-gnu-15.5.15.tgz",
+            "integrity": "sha512-nplqvY86LakS+eeiuWsNWvfmK8pFcOEW7ZtVRt4QH70lL+0x6LG/m1OpJ/tvrbwjmR8HH9/fH2jzW1GlL03TIg==",
             "cpu": [
                 "x64"
             ],
@@ -1993,9 +1993,9 @@
             }
         },
         "node_modules/@next/swc-linux-x64-musl": {
-            "version": "15.5.14",
-            "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-musl/-/swc-linux-x64-musl-15.5.14.tgz",
-            "integrity": "sha512-mMxv/FcrT7Gfaq4tsR22l17oKWXZmH/lVqcvjX0kfp5I0lKodHYLICKPoX1KRnnE+ci6oIUdriUhuA3rBCDiSw==",
+            "version": "15.5.15",
+            "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-musl/-/swc-linux-x64-musl-15.5.15.tgz",
+            "integrity": "sha512-eAgl9NKQ84/sww0v81DQINl/vL2IBxD7sMybd0cWRw6wqgouVI53brVRBrggqBRP/NWeIAE1dm5cbKYoiMlqDQ==",
             "cpu": [
                 "x64"
             ],
@@ -2009,9 +2009,9 @@
             }
         },
         "node_modules/@next/swc-win32-arm64-msvc": {
-            "version": "15.5.14",
-            "resolved": "https://registry.npmjs.org/@next/swc-win32-arm64-msvc/-/swc-win32-arm64-msvc-15.5.14.tgz",
-            "integrity": "sha512-OTmiBlYThppnvnsqx0rBqjDRemlmIeZ8/o4zI7veaXoeO1PVHoyj2lfTfXTiiGjCyRDhA10y4h6ZvZvBiynr2g==",
+            "version": "15.5.15",
+            "resolved": "https://registry.npmjs.org/@next/swc-win32-arm64-msvc/-/swc-win32-arm64-msvc-15.5.15.tgz",
+            "integrity": "sha512-GJVZC86lzSquh0MtvZT+L7G8+jMnJcldloOjA8Kf3wXvBrvb6OGe2MzPuALxFshSm/IpwUtD2mIoof39ymf52A==",
             "cpu": [
                 "arm64"
             ],
@@ -2025,9 +2025,9 @@
             }
         },
         "node_modules/@next/swc-win32-x64-msvc": {
-            "version": "15.5.14",
-            "resolved": "https://registry.npmjs.org/@next/swc-win32-x64-msvc/-/swc-win32-x64-msvc-15.5.14.tgz",
-            "integrity": "sha512-+W7eFf3RS7m4G6tppVTOSyP9Y6FsJXfOuKzav1qKniiFm3KFByQfPEcouHdjlZmysl4zJGuGLQ/M9XyVeyeNEg==",
+            "version": "15.5.15",
+            "resolved": "https://registry.npmjs.org/@next/swc-win32-x64-msvc/-/swc-win32-x64-msvc-15.5.15.tgz",
+            "integrity": "sha512-nFucjVdwlFqxh/JG3hWSJ4p8+YJV7Ii8aPDuBQULB6DzUF4UNZETXLfEUk+oI2zEznWWULPt7MeuTE6xtK1HSA==",
             "cpu": [
                 "x64"
             ],
@@ -7667,12 +7667,12 @@
             }
         },
         "node_modules/next": {
-            "version": "15.5.14",
-            "resolved": "https://registry.npmjs.org/next/-/next-15.5.14.tgz",
-            "integrity": "sha512-M6S+4JyRjmKic2Ssm7jHUPkE6YUJ6lv4507jprsSZLulubz0ihO2E+S4zmQK3JZ2ov81JrugukKU4Tz0ivgqqQ==",
+            "version": "15.5.15",
+            "resolved": "https://registry.npmjs.org/next/-/next-15.5.15.tgz",
+            "integrity": "sha512-VSqCrJwtLVGwAVE0Sb/yikrQfkwkZW9p+lL/J4+xe+G3ZA+QnWPqgcfH1tDUEuk9y+pthzzVFp4L/U8JerMfMQ==",
             "license": "MIT",
             "dependencies": {
-                "@next/env": "15.5.14",
+                "@next/env": "15.5.15",
                 "@swc/helpers": "0.5.15",
                 "caniuse-lite": "^1.0.30001579",
                 "postcss": "8.4.31",
@@ -7685,14 +7685,14 @@
                 "node": "^18.18.0 || ^19.8.0 || >= 20.0.0"
             },
             "optionalDependencies": {
-                "@next/swc-darwin-arm64": "15.5.14",
-                "@next/swc-darwin-x64": "15.5.14",
-                "@next/swc-linux-arm64-gnu": "15.5.14",
-                "@next/swc-linux-arm64-musl": "15.5.14",
-                "@next/swc-linux-x64-gnu": "15.5.14",
-                "@next/swc-linux-x64-musl": "15.5.14",
-                "@next/swc-win32-arm64-msvc": "15.5.14",
-                "@next/swc-win32-x64-msvc": "15.5.14",
+                "@next/swc-darwin-arm64": "15.5.15",
+                "@next/swc-darwin-x64": "15.5.15",
+                "@next/swc-linux-arm64-gnu": "15.5.15",
+                "@next/swc-linux-arm64-musl": "15.5.15",
+                "@next/swc-linux-x64-gnu": "15.5.15",
+                "@next/swc-linux-x64-musl": "15.5.15",
+                "@next/swc-win32-arm64-msvc": "15.5.15",
+                "@next/swc-win32-x64-msvc": "15.5.15",
                 "sharp": "^0.34.3"
             },
             "peerDependencies": {
@@ -7719,9 +7719,9 @@
             }
         },
         "node_modules/next-auth": {
-            "version": "4.24.13",
-            "resolved": "https://registry.npmjs.org/next-auth/-/next-auth-4.24.13.tgz",
-            "integrity": "sha512-sgObCfcfL7BzIK76SS5TnQtc3yo2Oifp/yIpfv6fMfeBOiBJkDWF3A2y9+yqnmJ4JKc2C+nMjSjmgDeTwgN1rQ==",
+            "version": "4.24.14",
+            "resolved": "https://registry.npmjs.org/next-auth/-/next-auth-4.24.14.tgz",
+            "integrity": "sha512-YRz6xFDXKUwiXSMMChbrBEWyFktZ1qZXEgeSHQQ3nsy08B4c/xLk6REeutRsIFwkjY/1+ShHnu07DN3JeJguig==",
             "license": "ISC",
             "dependencies": {
                 "@babel/runtime": "^7.20.13",

--- a/prisma/migrations/20260423121931_add_notification_is_read/migration.sql
+++ b/prisma/migrations/20260423121931_add_notification_is_read/migration.sql
@@ -1,0 +1,2 @@
+-- AlterTable
+ALTER TABLE "notification_records" ADD COLUMN     "is_read" BOOLEAN NOT NULL DEFAULT false;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -146,6 +146,7 @@ model NotificationRecord {
   memberId    String           @map("member_id")
   typeId      Int              @map("type_id")
   description String
+  isRead      Boolean          @default(false) @map("is_read")
   createdAt   DateTime         @default(now()) @map("created_at")
   member      Member           @relation(fields: [memberId], references: [id])
   type        NotificationType @relation(fields: [typeId], references: [id])

--- a/prisma/seed.ts
+++ b/prisma/seed.ts
@@ -155,15 +155,15 @@ const SCORE_POLICIES = [
 ];
 
 const NOTIFICATION_TYPES = [
-    { id: 1, name: "티어 승급", imageUrl: "/icons/Promote.ico" },
-    { id: 2, name: "티어 강등", imageUrl: "/icons/Relegation.ico" },
+    { id: 1, name: "티어 승급", imageUrl: "/icons/promotion.svg" },
+    { id: 2, name: "티어 강등", imageUrl: "/icons/relegation.svg" },
     {
         id: 3,
         name: "투기장 도전자 참여 완료",
-        imageUrl: "/icons/ArenaMatching.ico",
+        imageUrl: "/icons/recruitComplete.svg",
     },
-    { id: 4, name: "투기장 토론 시작", imageUrl: "/icons/AranaStart.ico" },
-    { id: 5, name: "투기장 투표 완료", imageUrl: "/icons/ArenaFinish.ico" },
+    { id: 4, name: "투기장 토론 시작", imageUrl: "/icons/debateStart.svg" },
+    { id: 5, name: "투기장 투표 완료", imageUrl: "/icons/voteComplete.svg" },
 ];
 
 async function main() {

--- a/tests/mocks/createMockNotificationRecordRepository.ts
+++ b/tests/mocks/createMockNotificationRecordRepository.ts
@@ -1,0 +1,13 @@
+import { vi } from "vitest";
+import type { NotificationRecordRepository } from "@/backend/notification-record/domain/repositories/NotificationRecordRepository";
+
+export function createMockNotificationRecordRepository(): NotificationRecordRepository {
+    return {
+        count: vi.fn(),
+        findAll: vi.fn(),
+        findById: vi.fn(),
+        save: vi.fn(),
+        update: vi.fn(),
+        deleteById: vi.fn(),
+    };
+}


### PR DESCRIPTION
## ✨ 작업 개요

알림 읽음 상태 관리, P0/P1 알림 트리거 구현, ECC 리뷰 반영

## ✅ 상세 내용

**핵심 기능**
- [x] DB 스키마에 `isRead` 필드 추가 (migration 포함)
- [x] 알림 읽음 처리 API (`PATCH /api/member/notification-records/[id]`)
- [x] 미읽음 알림 수 조회 API (`GET /api/member/notification-records/count`)
- [x] P0 알림 트리거: 티어 승강급 (`TierNotification.ts`)
- [x] P1 알림 트리거: 도전자 참가(3), 토론 시작(4), 투표 종료(5) (`ArenaTimerRecovery.ts`)
- [x] 알림 벨 버튼 미읽음 뱃지 표시 (`NotificationBellButton`)
- [x] 알림 모달 디자인 개선 (`NotificationModal`, `ModalWrapper`)

**ECC 리뷰 반영 (H/M/L 전 항목)**
- [x] H1: `fetch()` 응답 오류 미처리 수정 — `!res.ok` 시 throw
- [x] M0: `PrismaNotificationRecordRepository.update()` 필요 컬럼만 전달
- [x] M1: `GetNotificationRecordUsecase` N+1 쿼리 제거 → `findAll()` + Map 룩업
- [x] M2: `MarkNotificationReadUsecase` 이중 DB 조회 제거 → `execute(record)` 시그니처
- [x] M3: typeId 매직 넘버에 인라인 주석 추가
- [x] M4: `getWhereClause` Date 뮤테이션 수정
- [x] M5: `NotificationRecordItem`, `NotificationModal` 컴포넌트 테스트 추가 (9개)
- [x] M6: `text-[10px]`/`text-[11px]` → `text-caption` (CSS 규약 준수)
- [x] M7: `NotificationRecordDto`, `NotificationRecordListDto` 생성자 사용으로 수정
- [x] L1: `ModalWrapper` inner dialog에 `onKeyDown` Escape 핸들러 추가
- [x] L2: `Header.tsx` `flex hidden` 중복 클래스 제거
- [x] L3: `useNotificationCount` `staleTime: 30_000` 추가
- [x] L4: `CreateNotificationRecordUsecase` DB 기본값 중복 제거

 ## 📸 스크린샷 (선택)
<img width="1904" height="904" alt="image" src="https://github.com/user-attachments/assets/edee3b30-a422-42a9-8b44-f87c40747c66" />


## 🧪 확인 사항

- [x] 정상적으로 동작하는지 직접 테스트해봤나요?
- [x] 기능 추가/수정 후 UI나 비즈니스 로직에 영향은 없나요?
- [x] TypeScript (`tsc --noEmit`) Pass
- [x] Lint (`npm run lint`) Pass
- [x] Tests (`npm test`) Pass — 338 tests, 80 files
- [x] Build (`npm run build`) Pass

## 🙏 기타 참고 사항

알림 실패는 비핵심 경로로 분리되어 있어 메인 플로우(투기장 상태 전환, 출석, 좋아요)를 블로킹하지 않습니다.

## 이슈 관리

close #308